### PR TITLE
server: refine write process

### DIFF
--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -60,41 +60,43 @@ pegasus_write_service::pegasus_write_service(pegasus_server_impl *server)
 
 pegasus_write_service::~pegasus_write_service() = default;
 
-void pegasus_write_service::multi_put(int64_t decree,
-                                      const dsn::apps::multi_put_request &update,
-                                      dsn::apps::update_response &resp)
+int pegasus_write_service::multi_put(int64_t decree,
+                                     const dsn::apps::multi_put_request &update,
+                                     dsn::apps::update_response &resp)
 {
     uint64_t start_time = dsn_now_ns();
     _pfc_multi_put_qps->increment();
-    _impl->multi_put(decree, update, resp);
+    int err = _impl->multi_put(decree, update, resp);
     _pfc_multi_put_latency->set(dsn_now_ns() - start_time);
+    return err;
 }
 
-void pegasus_write_service::multi_remove(int64_t decree,
-                                         const dsn::apps::multi_remove_request &update,
-                                         dsn::apps::multi_remove_response &resp)
+int pegasus_write_service::multi_remove(int64_t decree,
+                                        const dsn::apps::multi_remove_request &update,
+                                        dsn::apps::multi_remove_response &resp)
 {
     uint64_t start_time = dsn_now_ns();
     _pfc_multi_remove_qps->increment();
-    _impl->multi_remove(decree, update, resp);
+    int err = _impl->multi_remove(decree, update, resp);
     _pfc_multi_remove_latency->set(dsn_now_ns() - start_time);
+    return err;
 }
 
-void pegasus_write_service::batch_put(const dsn::apps::update_request &update,
-                                      dsn::apps::update_response &resp)
+int pegasus_write_service::batch_put(const dsn::apps::update_request &update,
+                                     dsn::apps::update_response &resp)
 {
     _pfc_put_qps->increment();
     _batch_perfcounters.push_back(_pfc_put_latency.get());
 
-    _impl->batch_put(update, resp);
+    return _impl->batch_put(update, resp);
 }
 
-void pegasus_write_service::batch_remove(const dsn::blob &key, dsn::apps::update_response &resp)
+int pegasus_write_service::batch_remove(const dsn::blob &key, dsn::apps::update_response &resp)
 {
     _pfc_remove_qps->increment();
     _batch_perfcounters.push_back(_pfc_remove_latency.get());
 
-    _impl->batch_remove(key, resp);
+    return _impl->batch_remove(key, resp);
 }
 
 int pegasus_write_service::batch_commit(int64_t decree)
@@ -124,8 +126,11 @@ void pegasus_write_service::batch_prepare()
 int pegasus_write_service::empty_put(int64_t decree)
 {
     std::string empty_key, empty_value;
-    _impl->db_write_batch_put(empty_key, empty_value, 0);
-    return _impl->db_write(decree);
+    int err = _impl->db_write_batch_put(empty_key, empty_value, 0);
+    if (!err) {
+        err = _impl->db_write(decree);
+    }
+    return err;
 }
 
 } // namespace server

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <dsn/cpp/perf_counter_wrapper.h>
+#include <dsn/dist/replication/replica_base.h>
 
 #include "base/pegasus_value_schema.h"
 #include "base/pegasus_utils.h"
@@ -14,6 +15,10 @@ namespace pegasus {
 namespace server {
 
 class pegasus_server_impl;
+
+#define RETURN_NOT_ZERO(err)                                                                       \
+    if (dsn_unlikely(err))                                                                         \
+        return err;
 
 /// Handle the write requests.
 /// As the signatures imply, this class is not responsible for replying the rpc,
@@ -26,13 +31,13 @@ public:
 
     ~pegasus_write_service();
 
-    void multi_put(int64_t decree,
-                   const dsn::apps::multi_put_request &update,
-                   dsn::apps::update_response &resp);
+    int multi_put(int64_t decree,
+                  const dsn::apps::multi_put_request &update,
+                  dsn::apps::update_response &resp);
 
-    void multi_remove(int64_t decree,
-                      const dsn::apps::multi_remove_request &update,
-                      dsn::apps::multi_remove_response &resp);
+    int multi_remove(int64_t decree,
+                     const dsn::apps::multi_remove_request &update,
+                     dsn::apps::multi_remove_response &resp);
 
     /// Prepare for batch write.
     void batch_prepare();
@@ -44,9 +49,9 @@ public:
 
     /// NOTE that `resp` should not be moved or freed while
     /// the batch is not committed.
-    void batch_put(const dsn::apps::update_request &update, dsn::apps::update_response &resp);
+    int batch_put(const dsn::apps::update_request &update, dsn::apps::update_response &resp);
 
-    void batch_remove(const dsn::blob &key, dsn::apps::update_response &resp);
+    int batch_remove(const dsn::blob &key, dsn::apps::update_response &resp);
 
     /// \returns 0 if success, non-0 if failure.
     /// If the batch contains no updates, 0 is returned.

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -132,9 +132,8 @@ public:
         if (dsn_unlikely(!s.ok())) {
             derror_rocksdb("WriteBatchPut",
                            s.ToString(),
-                           "raw_key: {}, value: {}, expire_sec: {}",
-                           raw_key,
-                           value,
+                           "raw_key: {}, expire_sec: {}",
+                           utils::c_escape_string(raw_key),
                            expire_sec);
         }
         return s.code();
@@ -144,7 +143,8 @@ public:
     {
         rocksdb::Status s = _batch.Delete(utils::to_rocksdb_slice(raw_key));
         if (dsn_unlikely(!s.ok())) {
-            derror_rocksdb("WriteBatchDelete", s.ToString(), "raw_key: {}", raw_key);
+            derror_rocksdb(
+                "WriteBatchDelete", s.ToString(), "raw_key: {}", utils::c_escape_string(raw_key));
         }
         return s.code();
     }


### PR DESCRIPTION
- **bugfix**: multi_put and multi_remove won't return error for invalid user argument

- batch_write and batch_remove will return error when rocksdb::WriteBatch failed. We used to assume it always returns OK.

- add logging on batch write error.