### PR TITLE
shell: support change cluster

### DIFF
--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -544,6 +544,20 @@ inline bool use_app_as_current(command_executor *e, shell_context *sc, arguments
     }
 }
 
+extern void check_in_cluster(std::string cluster_name);
+
+inline bool cc_command(command_executor *e, shell_context *sc, arguments args)
+{
+    if (args.argc == 2) {
+        std::string cluster_name = args.argv[1];
+        if (!cluster_name.empty()) {
+            check_in_cluster(cluster_name);
+            return true;
+        }
+    }
+    return false;
+}
+
 inline bool process_escape_all(command_executor *e, shell_context *sc, arguments args)
 {
     if (args.argc == 1) {


### PR DESCRIPTION
This PR I introduce a new command called `cc [cluster_name]`, which can change the current working cluster. This command is useful when we open pegasus shell in [gotty](https://github.com/yudai/gotty), for example when we run `gotty -w ./run.sh shell`, we are not able to re-specify the cluster:

```
task_spec.cpp:94:register_task_code():overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX from THREAD_POOL_DEFAULT to THREAD_POOL_META_SERVER
task_spec.cpp:94:register_task_code():overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX_ACK from THREAD_POOL_DEFAULT to THREAD_POOL_META_SERVER
task_spec.cpp:94:register_task_code():overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX from THREAD_POOL_META_SERVER to THREAD_POOL_DEFAULT
task_spec.cpp:94:register_task_code():overwrite default thread pool for task RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX_ACK from THREAD_POOL_META_SERVER to THREAD_POOL_DEFAULT
Pegasus Shell 1.12.SNAPSHOT
Type "help" for more information.
Type "Ctrl-D" or "Ctrl-C" to exit the shell.

service_api_c.cpp:314:run():dsn_runtime_init_time_ms = 1540480394003 (2018-10-25 23:13:14.003)
The config file is: /home/wutao1/work/pegasus/pegasus-tools-1.12.SNAPSHOT-9680d17--release/config-shell.ini.35339
The cluster name is: onebox
The cluster meta list is: 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
>>> cc c3srv-ad
The cluster name is: c3srv-ad
The cluster meta list is: XXXX:37601,XXXX:37601
>>> nodes -d
address                 status              replica_count       primary_count       secondary_count
XX.XXX.XX.XXX:37801      ALIVE               114                 38                  76

>>> cc hytst-staging2
The cluster name is: hytst-staging2
The cluster meta list is: XXXX:38601,XXXX:38601
>>> nodes -d
address               status              replica_count       primary_count       secondary_count
XX.XXX.XX.XXX:38801     ALIVE               375                 150                 225
```

![image](https://user-images.githubusercontent.com/6970676/47511303-7d1fa300-d8ac-11e8-8180-76932f4b7de5.png)
