### PR TITLE
scripts: fix get_xx_lib funcs in pack_common.sh

### DIFF
--- a/scripts/pack_common.sh
+++ b/scripts/pack_common.sh
@@ -21,7 +21,7 @@ function get_stdcpp_lib()
     else
         libs=(`ldconfig -p|grep $libname|awk '{print $NF}'`)
 
-        for lib in ${libs[*]}; do 
+        for lib in ${libs[*]}; do
             if [ "`check_bit $lib`" = "true" ]; then
                 echo "$lib"
                 return
@@ -71,8 +71,8 @@ function check_bit()
         check_bit=`file $lib |grep "$bit_mode-bit"`
     else
         real_lib_name=`ls -l $lib |awk '{print $NF}'`
-    	lib_path=${lib%/*} 
-	    real_lib=${lib_path}"/"${real_lib_name}
+        lib_path=${lib%/*} 
+        real_lib=${lib_path}"/"${real_lib_name}
         check_bit=`file $real_lib |grep "$bit_mode-bit"`
     fi
     if [ -n "$check_bit" ]; then

--- a/scripts/pack_common.sh
+++ b/scripts/pack_common.sh
@@ -17,9 +17,16 @@ function get_stdcpp_lib()
     libname=`echo $libname | cut -f1 -d" "`
     if [ $1 = "true" ]; then
         gcc_path=`which gcc`
-        echo `dirname $gcc_path`/../lib64/$libname
+        echo `dirname $gcc_path`/../lib64/$libname #TODO need fix
     else
-        echo `ldconfig -p|grep $libname|awk '{print $NF}'`
+        libs=(`ldconfig -p|grep $libname|awk '{print $NF}'`)
+
+        for lib in ${libs[*]}; do 
+            if [ "`check_bit $lib`" = "true" ]; then
+                echo "$lib"
+                return
+            fi
+        done;
     fi
 }
 
@@ -28,7 +35,15 @@ function get_system_lib()
 {
     libname=`ldd ./DSN_ROOT/bin/pegasus_$1/pegasus_$1 2>/dev/null | grep "lib${2}\.so"`
     libname=`echo $libname | cut -f1 -d" "`
-    echo `ldconfig -p|grep $libname|awk '{print $NF}'`
+    libs=(`ldconfig -p|grep $libname|awk '{print $NF}'`)
+
+    bit_mode=`getconf LONG_BIT`
+    for lib in ${libs[*]}; do
+        if [ "`check_bit $lib`" = "true" ]; then
+            echo "$lib"
+            return
+        fi
+    done;
 }
 
 #USAGE: copy_file src [src...] dest
@@ -42,6 +57,26 @@ function copy_file()
     if [ $? -ne 0 ]; then
         echo "ERROR: copy file failed: cp $*"
         exit 1
+    fi
+}
+
+function check_bit()
+{
+    bit_mode=`getconf LONG_BIT`
+    lib=$1
+    check_bit=""
+    is_softlink=`file $lib | grep "symbolic link"`
+    
+    if [ -z "$is_softlink" ]; then
+        check_bit=`file $lib |grep "$bit_mode-bit"`
+    else
+        real_lib_name=`ls -l $lib |awk '{print $NF}'`
+    	lib_path=${lib%/*} 
+	    real_lib=${lib_path}"/"${real_lib_name}
+        check_bit=`file $real_lib |grep "$bit_mode-bit"`
+    fi
+    if [ -n "$check_bit" ]; then
+        echo "true"
     fi
 }
 


### PR DESCRIPTION
add 32/64-bit check when getting stdcpp or system lib
only allows one lib to be found