### PR TITLE
shell: add a tool to help matrix data output

### DIFF
--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -3603,6 +3603,32 @@ inline bool app_disk(command_executor *e, shell_context *sc, arguments args)
     return true;
 }
 
+struct output_matrix {
+    void add_column(const std::string &col_name) {
+        if (matrix_data.empty()) {
+            add_row();
+        }
+        dassert_f(matrix_data.size() == 1, "`add_column` must be called before real data appendding");
+        append_data(col_name);
+    }
+
+    void add_row() {
+        matrix_data.emplace_back(std::vector<std::string>());
+    }
+
+    void append_data(const std::string &data) {
+        matrix_data.rbegin()->emplace_back(data);
+    }
+
+    void output(std::ostream &out) {
+
+    }
+
+    static const int space_width = 2;
+    std::list<int> max_col_width;
+    std::vector<std::vector<std::string>> matrix_data;
+};
+
 inline bool app_stat(command_executor *e, shell_context *sc, arguments args)
 {
     static struct option long_options[] = {{"app_name", required_argument, 0, 'a'},
@@ -3652,7 +3678,10 @@ inline bool app_stat(command_executor *e, shell_context *sc, arguments args)
     }
     std::ostream out(buf);
 
-    static const size_t w = 10;
+    output_matrix om;
+
+
+    static const size_t w = 14;
     size_t first_column_width = w;
     if (app_name.empty()) {
         for (row_data &row : rows) {

--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -3609,22 +3609,22 @@ struct table_printer
     {
         dassert_f(matrix_data.empty() && max_col_width.empty(),
                   "`add_title` must be called only once");
-        add_row(title);
         max_col_width.push_back(title.length());
+        add_row(title);
     }
 
     void add_column(const std::string &col_name)
     {
         dassert_f(matrix_data.size() == 1,
                   "`add_column` must be called before real data appendding");
-        max_col_width.push_back(col_name.length());
+        max_col_width.emplace_back(col_name.length());
         append_data(col_name);
     }
 
     void add_row(const std::string &row_name)
     {
         matrix_data.emplace_back(std::vector<std::string>());
-        matrix_data.rbegin()->push_back(row_name);
+        append_data(row_name);
     }
 
     void append_data(const std::string &data)

--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -3764,10 +3764,10 @@ inline bool app_stat(command_executor *e, shell_context *sc, arguments args)
         tp.add_column("expired");
         tp.add_column("filtered");
         tp.add_column("abnormal");
-        tp.add_column("file_size(MB)");
+        tp.add_column("file_mb");
         tp.add_column("file_num");
         tp.add_column("hit_rate");
-        tp.add_column("mem_usage(MB)");
+        tp.add_column("rdb_mem_mb");
     }
 
     for (row_data &row : rows) {

--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -3603,8 +3603,9 @@ inline bool app_disk(command_executor *e, shell_context *sc, arguments args)
     return true;
 }
 
-struct table_printer
+class table_printer
 {
+public:
     void add_title(const std::string &title)
     {
         dassert_f(matrix_data.empty() && max_col_width.empty(),
@@ -3625,17 +3626,6 @@ struct table_printer
     {
         matrix_data.emplace_back(std::vector<std::string>());
         append_data(row_name);
-    }
-
-    void append_data(const std::string &data)
-    {
-        matrix_data.rbegin()->emplace_back(data);
-
-        // update column max length
-        int &cur_len = max_col_width[matrix_data.rbegin()->size() - 1];
-        if (cur_len < data.size()) {
-            cur_len = data.size();
-        }
     }
 
     void append_data(uint64_t data) { append_data(std::to_string(data)); }
@@ -3667,6 +3657,19 @@ struct table_printer
         }
     }
 
+private:
+    void append_data(const std::string &data)
+    {
+        matrix_data.rbegin()->emplace_back(data);
+
+        // update column max length
+        int &cur_len = max_col_width[matrix_data.rbegin()->size() - 1];
+        if (cur_len < data.size()) {
+            cur_len = data.size();
+        }
+    }
+
+private:
     static const int precision = 2;
     static const int space_width = 2;
     std::vector<int> max_col_width;


### PR DESCRIPTION
add a class `table_printer` to help matrix data output, it's more convenient to add column name, row name and their data, the output data will align itself. 