### PR TITLE
bugfix: use std::abs explicit to avoid reference to cstdlib abs, which will c…

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -645,7 +645,7 @@ public:
 
     void append_data(double data)
     {
-        if (abs(data) < 1e-6) {
+        if (std::abs(data) < 1e-6) {
             append_data("0.00");
         } else {
             std::stringstream s;


### PR DESCRIPTION
use std::abs explicit to avoid reference to cstdlib abs, which will convert double to int