### PR TITLE
falcon: fix invalid json format

### DIFF
--- a/scripts/falcon_screen.json
+++ b/scripts/falcon_screen.json
@@ -633,7 +633,7 @@
       "title": "各节点最近读写失败次数",
       "endpoints": ["cluster=${cluster.name} job=replica service=pegasus"],
       "counters": [
-          "replica*eon.replica_stub*recent.read.fail.count/cluster=${cluster.name},job=replica,port=${replica.port},service=pegasus"
+          "replica*eon.replica_stub*recent.read.fail.count/cluster=${cluster.name},job=replica,port=${replica.port},service=pegasus",
           "replica*eon.replica_stub*recent.write.fail.count/cluster=${cluster.name},job=replica,port=${replica.port},service=pegasus"
       ],
       "graph_type": "a",


### PR DESCRIPTION
Fix invalid json format, otherwise falcon_screen.py can't decode current falcon_screen.json 