### PR TITLE
scripts: fix pack tools to copy lib with the right name

### DIFF
--- a/scripts/pack_common.sh
+++ b/scripts/pack_common.sh
@@ -53,6 +53,14 @@ function get_system_lib()
     fi
 }
 
+# USAGE: get_system_libname server snappy
+function get_system_libname()
+{
+    libname=`ldd ./DSN_ROOT/bin/pegasus_$1/pegasus_$1 2>/dev/null | grep "lib${2}\.so"`
+    libname=`echo $libname | cut -f1 -d" "`
+    echo "$libname"
+}
+
 #USAGE: copy_file src [src...] dest
 function copy_file()
 {

--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -98,12 +98,12 @@ copy_file ./src/server/config.ini ${pack}/bin
 copy_file `get_boost_lib $custom_boost_lib system` ${pack}/bin
 copy_file `get_boost_lib $custom_boost_lib filesystem` ${pack}/bin
 copy_file `get_stdcpp_lib $custom_gcc` ${pack}/bin
-copy_file `get_system_lib server snappy` ${pack}/bin
-copy_file `get_system_lib server crypto` ${pack}/bin
-copy_file `get_system_lib server ssl` ${pack}/bin
-copy_file `get_system_lib server aio` ${pack}/bin
-copy_file `get_system_lib server zstd` ${pack}/bin
-copy_file `get_system_lib server lz4` ${pack}/bin
+copy_file `get_system_lib server snappy` ${pack}/bin/`get_system_libname server snappy`
+copy_file `get_system_lib server crypto` ${pack}/bin/`get_system_libname server crypto`
+copy_file `get_system_lib server ssl` ${pack}/bin/`get_system_libname server ssl`
+copy_file `get_system_lib server aio` ${pack}/bin/`get_system_libname server aio`
+copy_file `get_system_lib server zstd` ${pack}/bin/`get_system_libname server zstd`
+copy_file `get_system_lib server lz4` ${pack}/bin/`get_system_libname server lz4`
 
 chmod +x ${pack}/bin/pegasus_* ${pack}/bin/*.sh
 chmod -x ${pack}/bin/lib*

--- a/scripts/pack_tools.sh
+++ b/scripts/pack_tools.sh
@@ -104,12 +104,12 @@ copy_file ./rdsn/thirdparty/output/lib/libtcmalloc.so.4 ${pack}/DSN_ROOT/lib/
 copy_file `get_boost_lib $custom_boost_lib system` ${pack}/DSN_ROOT/lib/
 copy_file `get_boost_lib $custom_boost_lib filesystem` ${pack}/DSN_ROOT/lib/
 copy_file `get_stdcpp_lib $custom_gcc` ${pack}/DSN_ROOT/lib/
-copy_file `get_system_lib shell snappy` ${pack}/DSN_ROOT/lib/
-copy_file `get_system_lib shell crypto` ${pack}/DSN_ROOT/lib/
-copy_file `get_system_lib shell ssl` ${pack}/DSN_ROOT/lib/
-copy_file `get_system_lib shell aio` ${pack}/DSN_ROOT/lib/
-copy_file `get_system_lib shell zstd` ${pack}/DSN_ROOT/lib/
-copy_file `get_system_lib shell lz4` ${pack}/DSN_ROOT/lib/
+copy_file `get_system_lib shell snappy` ${pack}/DSN_ROOT/lib/`get_system_libname shell snappy`
+copy_file `get_system_lib shell crypto` ${pack}/DSN_ROOT/lib/`get_system_libname shell crypto`
+copy_file `get_system_lib shell ssl` ${pack}/DSN_ROOT/lib/`get_system_libname shell ssl`
+copy_file `get_system_lib shell aio` ${pack}/DSN_ROOT/lib/`get_system_libname shell aio`
+copy_file `get_system_lib shell zstd` ${pack}/DSN_ROOT/lib/`get_system_libname shell zstd`
+copy_file `get_system_lib shell lz4` ${pack}/DSN_ROOT/lib/`get_system_libname shell lz4`
 chmod -x ${pack}/DSN_ROOT/lib/*
 
 mkdir -p ${pack}/scripts


### PR DESCRIPTION
to fix the `lib file name not match` problem like:
- ldd pegasus_server: libaio.so.1 => /lib64/libaio.so.1
- pack_server: DSN_ROOT/lib/libaio.so.1.0.0