### PR TITLE
 shell: improve subcommand app_stat and nodes

### DIFF
--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -102,7 +102,6 @@ void info_collector::on_app_stat()
             all.storage_count += row.storage_count;
             all.rdb_block_cache_hit_count += row.rdb_block_cache_hit_count;
             all.rdb_block_cache_total_count += row.rdb_block_cache_total_count;
-            all.rdb_block_cache_mem_usage += row.rdb_block_cache_mem_usage;
             all.rdb_index_and_filter_blocks_mem_usage += row.rdb_index_and_filter_blocks_mem_usage;
             all.rdb_memtable_mem_usage += row.rdb_memtable_mem_usage;
             read_qps[i] = row.get_qps + row.multi_get_qps + row.scan_qps;
@@ -139,7 +138,6 @@ void info_collector::on_app_stat()
                 std::abs(row.rdb_block_cache_total_count) < 1e-6
                     ? 0
                     : row.rdb_block_cache_hit_count / row.rdb_block_cache_total_count * 1000000);
-            counters->rdb_block_cache_mem_usage->set(row.rdb_block_cache_mem_usage);
             counters->rdb_index_and_filter_blocks_mem_usage->set(
                 row.rdb_index_and_filter_blocks_mem_usage);
             counters->rdb_memtable_mem_usage->set(row.rdb_memtable_mem_usage);
@@ -192,7 +190,6 @@ info_collector::AppStatCounters *info_collector::get_app_counters(const std::str
     INIT_COUNTER(storage_mb);
     INIT_COUNTER(storage_count);
     INIT_COUNTER(rdb_block_cache_hit_rate);
-    INIT_COUNTER(rdb_block_cache_mem_usage);
     INIT_COUNTER(rdb_index_and_filter_blocks_mem_usage);
     INIT_COUNTER(rdb_memtable_mem_usage);
     INIT_COUNTER(read_qps);

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -485,7 +485,6 @@ struct row_data
     double storage_count = 0;
     double rdb_block_cache_hit_count = 0;
     double rdb_block_cache_total_count = 0;
-    double rdb_block_cache_mem_usage = 0;
     double rdb_index_and_filter_blocks_mem_usage = 0;
     double rdb_memtable_mem_usage = 0;
 };
@@ -531,8 +530,6 @@ update_app_pegasus_perf_counter(row_data &row, const std::string &counter_name, 
         row.rdb_block_cache_hit_count += value;
     else if (counter_name == "rdb.block_cache.total_count")
         row.rdb_block_cache_total_count += value;
-    else if (counter_name == "rdb.block_cache.memory_usage")
-        row.rdb_block_cache_mem_usage += value;
     else if (counter_name == "rdb.index_and_filter_blocks.memory_usage")
         row.rdb_index_and_filter_blocks_mem_usage += value;
     else if (counter_name == "rdb.memtable.memory_usage")

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -56,7 +56,7 @@ static command_executor commands[] = {
     {
         "nodes",
         "get the node status for this cluster",
-        "[-d|--detailed] [-r|--resolve_ip] [-m|--memory_usage] "
+        "[-d|--detailed] [-r|--resolve_ip] [-u|--resource_usage] "
         "[-o|--output file_name] [-s|--status all|alive|unalive]",
         ls_nodes,
     },

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -56,7 +56,8 @@ static command_executor commands[] = {
     {
         "nodes",
         "get the node status for this cluster",
-        "[-d|--detailed] [-o|--output file_name] [-s|--status all|alive|unalive]",
+        "[-d|--detailed] [-r|--resolve_ip] "
+        "[-o|--output file_name] [-s|--status all|alive|unalive]",
         ls_nodes,
     },
     {

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -56,7 +56,7 @@ static command_executor commands[] = {
     {
         "nodes",
         "get the node status for this cluster",
-        "[-d|--detailed] [-r|--resolve_ip] "
+        "[-d|--detailed] [-r|--resolve_ip] [-m|--memory_usage] "
         "[-o|--output file_name] [-s|--status all|alive|unalive]",
         ls_nodes,
     },


### PR DESCRIPTION
for app_stat:
* split column `rdb_mem_mb` to `mem_tbl_mb` and `mem_idx_mb`.

for nodes:
* add `-r|--resolve_ip` option.
* add `-u|--resource_usage` option to add columns: `memused_res_mb`, `block_cache_mb`, `mem_tbl_mb  mem_idx_mb`, `disk_avl_total_ratio`, `disk_avl_min_ratio`.