### PR TITLE
bugfix: fix redis proxy set ttl bug; fix unit test

### DIFF
--- a/src/include/pegasus/client.h
+++ b/src/include/pegasus/client.h
@@ -1045,12 +1045,13 @@ public:
     /// \param sortkey
     /// all the k-v under hashkey will be sorted by sortkey.
     /// \param ttl_seconds
-    /// the returned ttl value in seconds.
+    /// the returned ttl value in seconds. -1 means no ttl.
     /// \param timeout_milliseconds
     /// if wait longer than this value, will return time out error
     /// \return
     /// int, the error indicates whether or not the operation is succeeded.
-    /// this error can be converted to a string using get_error_string()
+    /// this error can be converted to a string using get_error_string().
+    /// returns PERR_NOT_FOUND if no value is found under the <hashkey,sortkey>.
     ///
     virtual int ttl(const std::string &hashkey,
                     const std::string &sortkey,

--- a/src/redis_protocol/proxy_lib/redis_parser.cpp
+++ b/src/redis_protocol/proxy_lib/redis_parser.cpp
@@ -451,7 +451,10 @@ void redis_parser::set_internal(redis_parser::message_entry &entry)
         ::dsn::blob null_blob;
         pegasus_generate_key(req.key, request.buffers[1].data, null_blob);
         req.value = request.buffers[2].data;
-        req.expire_ts_seconds = ttl_seconds;
+        if (ttl_seconds == 0)
+            req.expire_ts_seconds = 0;
+        else
+            req.expire_ts_seconds = ttl_seconds + utils::epoch_now();
         auto partition_hash = pegasus_key_hash(req.key);
         // TODO: set the timeout
         client->put(req, on_set_reply, std::chrono::milliseconds(2000), 0, partition_hash);

--- a/src/test/function_test/test_ttl.cpp
+++ b/src/test/function_test/test_ttl.cpp
@@ -148,7 +148,7 @@ TEST(ttl, set_with_default_ttl)
     int ttl_seconds;
     ret = client->ttl(ttl_hash_key, ttl_test_sort_key_1, ttl_seconds);
     ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(ttl_seconds > specify_ttl - error_allow && ttl_seconds <= specify_ttl)
+    ASSERT_TRUE(ttl_seconds >= specify_ttl - error_allow && ttl_seconds <= specify_ttl)
         << "ttl is " << ttl_seconds;
 
     // set without ttl
@@ -161,7 +161,7 @@ TEST(ttl, set_with_default_ttl)
 
     ret = client->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds);
     ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(ttl_seconds > default_ttl - error_allow && ttl_seconds <= default_ttl)
+    ASSERT_TRUE(ttl_seconds >= default_ttl - error_allow && ttl_seconds <= default_ttl)
         << "ttl is " << ttl_seconds;
 
     // sleep a while
@@ -182,8 +182,8 @@ TEST(ttl, set_with_default_ttl)
     // check exist one
     ret = client->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds);
     ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(ttl_seconds > default_ttl - sleep_for_expiring - error_allow &&
-                ttl_seconds <= default_ttl - sleep_for_expiring)
+    ASSERT_TRUE(ttl_seconds >= default_ttl - sleep_for_expiring - error_allow &&
+                ttl_seconds <= default_ttl - sleep_for_expiring + error_allow)
         << "ttl is " << ttl_seconds;
 
     ret = client->get(ttl_hash_key, ttl_test_sort_key_2, value);
@@ -202,8 +202,8 @@ TEST(ttl, set_with_default_ttl)
     // check forever one
     ret = client->ttl(ttl_hash_key, ttl_test_sort_key_0, ttl_seconds);
     ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(ttl_seconds > default_ttl - sleep_for_envs_effect - error_allow &&
-                ttl_seconds <= default_ttl - error_allow)
+    ASSERT_TRUE(ttl_seconds >= default_ttl - sleep_for_envs_effect - error_allow &&
+                ttl_seconds <= default_ttl + error_allow)
         << "ttl is " << ttl_seconds;
 
     // check expired one
@@ -216,8 +216,8 @@ TEST(ttl, set_with_default_ttl)
     // check exist one
     ret = client->ttl(ttl_hash_key, ttl_test_sort_key_2, ttl_seconds);
     ASSERT_EQ(PERR_OK, ret);
-    ASSERT_TRUE(ttl_seconds >
-                    default_ttl - sleep_for_expiring - sleep_for_envs_effect - error_allow &&
-                ttl_seconds <= default_ttl - sleep_for_expiring - sleep_for_envs_effect)
+    ASSERT_TRUE(
+        ttl_seconds >= default_ttl - sleep_for_expiring - sleep_for_envs_effect - error_allow &&
+        ttl_seconds <= default_ttl - sleep_for_expiring - sleep_for_envs_effect + error_allow)
         << "ttl is " << ttl_seconds;
 }


### PR DESCRIPTION
fix the unit test failure:
```
/home/travis/build/XiaoMi/pegasus/src/test/function_test/test_ttl.cpp:221: Failure
Value of: ttl_seconds > default_ttl - sleep_for_expiring - sleep_for_envs_effect - error_allow && ttl_seconds <= default_ttl - sleep_for_expiring - sleep_for_envs_effect
  Actual: false
Expected: true
ttl is 3526
```