### PR TITLE
refactor: remove some useless configs

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,4 +1,0 @@
-{
-    "project_id": "Pegasus",
-    "conduit_uri": "https://phabricator.d.xiaomi.net"
-}

--- a/src/base/test/config.ini
+++ b/src/base/test/config.ini
@@ -19,8 +19,6 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/base/test/config.ini
+++ b/src/base/test/config.ini
@@ -54,7 +54,6 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 4
 

--- a/src/base/test/config.ini
+++ b/src/base/test/config.ini
@@ -21,7 +21,6 @@ tool = nativerun
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger

--- a/src/base/test/config.ini
+++ b/src/base/test/config.ini
@@ -58,7 +58,6 @@ worker_count = 4
 is_trace = false
 is_profile = false
 allow_inline = false
-fast_execution_in_network_thread = false
 rpc_call_header_format = NET_HDR_DSN
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_timeout_milliseconds = 5000

--- a/src/base/test/config.ini
+++ b/src/base/test/config.ini
@@ -28,7 +28,6 @@ start_nfs = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
-;logging_factory_name = dsn::tools::hpc_logger
 logging_flush_on_exit = true
 
 enable_default_app_mimic = true
@@ -40,10 +39,6 @@ short_header = true
 fast_flush = true
 max_number_of_log_files_on_disk = 10
 stderr_start_level = LOG_LEVEL_ERROR
-
-[tools.hpc_logger]
-per_thread_buffer_bytes = 8192
-max_number_of_log_files_on_disk = 10
 
 [tools.simulator]
 random_seed = 0

--- a/src/base/test/config.ini
+++ b/src/base/test/config.ini
@@ -14,7 +14,6 @@ count = 1
 
 [core]
 ;tool = simulator
-;tool = fastrun
 tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector

--- a/src/geo/bench/config.ini
+++ b/src/geo/bench/config.ini
@@ -19,8 +19,6 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/geo/bench/config.ini
+++ b/src/geo/bench/config.ini
@@ -54,7 +54,6 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 4
 

--- a/src/geo/bench/config.ini
+++ b/src/geo/bench/config.ini
@@ -21,7 +21,6 @@ tool = nativerun
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger

--- a/src/geo/bench/config.ini
+++ b/src/geo/bench/config.ini
@@ -58,7 +58,6 @@ worker_count = 4
 is_trace = false
 is_profile = false
 allow_inline = false
-fast_execution_in_network_thread = false
 rpc_call_header_format = NET_HDR_DSN
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_timeout_milliseconds = 5000

--- a/src/geo/bench/config.ini
+++ b/src/geo/bench/config.ini
@@ -28,7 +28,6 @@ start_nfs = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
-;logging_factory_name = dsn::tools::hpc_logger
 logging_flush_on_exit = true
 
 enable_default_app_mimic = true
@@ -40,10 +39,6 @@ short_header = true
 fast_flush = true
 max_number_of_log_files_on_disk = 10
 stderr_start_level = LOG_LEVEL_ERROR
-
-[tools.hpc_logger]
-per_thread_buffer_bytes = 8192
-max_number_of_log_files_on_disk = 10
 
 [tools.simulator]
 random_seed = 0

--- a/src/geo/bench/config.ini
+++ b/src/geo/bench/config.ini
@@ -14,7 +14,6 @@ count = 1
 
 [core]
 ;tool = simulator
-;tool = fastrun
 tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector

--- a/src/geo/test/config.ini
+++ b/src/geo/test/config.ini
@@ -19,8 +19,6 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/geo/test/config.ini
+++ b/src/geo/test/config.ini
@@ -54,7 +54,6 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 4
 

--- a/src/geo/test/config.ini
+++ b/src/geo/test/config.ini
@@ -21,7 +21,6 @@ tool = nativerun
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger

--- a/src/geo/test/config.ini
+++ b/src/geo/test/config.ini
@@ -58,7 +58,6 @@ worker_count = 4
 is_trace = false
 is_profile = false
 allow_inline = false
-fast_execution_in_network_thread = false
 rpc_call_header_format = NET_HDR_DSN
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_timeout_milliseconds = 5000

--- a/src/geo/test/config.ini
+++ b/src/geo/test/config.ini
@@ -28,7 +28,6 @@ start_nfs = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
-;logging_factory_name = dsn::tools::hpc_logger
 logging_flush_on_exit = true
 
 enable_default_app_mimic = true
@@ -40,10 +39,6 @@ short_header = true
 fast_flush = true
 max_number_of_log_files_on_disk = 10
 stderr_start_level = LOG_LEVEL_ERROR
-
-[tools.hpc_logger]
-per_thread_buffer_bytes = 8192
-max_number_of_log_files_on_disk = 10
 
 [tools.simulator]
 random_seed = 0

--- a/src/geo/test/config.ini
+++ b/src/geo/test/config.ini
@@ -14,7 +14,6 @@ count = 1
 
 [core]
 ;tool = simulator
-;tool = fastrun
 tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector

--- a/src/redis_protocol/proxy/config.ini
+++ b/src/redis_protocol/proxy/config.ini
@@ -60,7 +60,6 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 4
 

--- a/src/redis_protocol/proxy/config.ini
+++ b/src/redis_protocol/proxy/config.ini
@@ -29,8 +29,6 @@ tool = nativerun
 toollets = profiler
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/redis_protocol/proxy/config.ini
+++ b/src/redis_protocol/proxy/config.ini
@@ -70,7 +70,6 @@ is_trace = false
 is_profile = false
 allow_inline = false
 rpc_call_channel = RPC_CHANNEL_TCP
-fast_execution_in_network_thread = false
 rpc_call_header_format_name = dsn
 rpc_timeout_milliseconds = 5000
 

--- a/src/redis_protocol/proxy/config.ini
+++ b/src/redis_protocol/proxy/config.ini
@@ -31,7 +31,6 @@ toollets = profiler
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger

--- a/src/redis_protocol/proxy/config.ini
+++ b/src/redis_protocol/proxy/config.ini
@@ -24,7 +24,6 @@ delay_seconds = 30
 
 [core]
 ;tool = simulator
-;tool = fastrun
 tool = nativerun
 toollets = profiler
 ;toollets = tracer, profiler, fault_injector

--- a/src/redis_protocol/proxy_ut/config.ini
+++ b/src/redis_protocol/proxy_ut/config.ini
@@ -60,7 +60,6 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 4
 

--- a/src/redis_protocol/proxy_ut/config.ini
+++ b/src/redis_protocol/proxy_ut/config.ini
@@ -29,8 +29,6 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/redis_protocol/proxy_ut/config.ini
+++ b/src/redis_protocol/proxy_ut/config.ini
@@ -70,7 +70,6 @@ is_trace = false
 is_profile = false
 allow_inline = false
 rpc_call_channel = RPC_CHANNEL_TCP
-fast_execution_in_network_thread = false
 rpc_call_header_format_name = dsn
 rpc_timeout_milliseconds = 5000
 

--- a/src/redis_protocol/proxy_ut/config.ini
+++ b/src/redis_protocol/proxy_ut/config.ini
@@ -31,7 +31,6 @@ tool = nativerun
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_INFORMATION
 logging_factory_name = dsn::tools::simple_logger

--- a/src/redis_protocol/proxy_ut/config.ini
+++ b/src/redis_protocol/proxy_ut/config.ini
@@ -24,7 +24,6 @@ delay_seconds = 30
 
 [core]
 ;tool = simulator
-;tool = fastrun
 tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector

--- a/src/sample/config.ini
+++ b/src/sample/config.ini
@@ -19,8 +19,6 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/sample/config.ini
+++ b/src/sample/config.ini
@@ -54,7 +54,6 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 4
 

--- a/src/sample/config.ini
+++ b/src/sample/config.ini
@@ -21,7 +21,6 @@ tool = nativerun
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger

--- a/src/sample/config.ini
+++ b/src/sample/config.ini
@@ -58,7 +58,6 @@ worker_count = 4
 is_trace = false
 is_profile = false
 allow_inline = false
-fast_execution_in_network_thread = false
 rpc_call_header_format = NET_HDR_DSN
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_timeout_milliseconds = 5000

--- a/src/sample/config.ini
+++ b/src/sample/config.ini
@@ -28,7 +28,6 @@ start_nfs = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
-;logging_factory_name = dsn::tools::hpc_logger
 logging_flush_on_exit = true
 
 enable_default_app_mimic = true
@@ -40,10 +39,6 @@ short_header = true
 fast_flush = true
 max_number_of_log_files_on_disk = 10
 stderr_start_level = LOG_LEVEL_ERROR
-
-[tools.hpc_logger]
-per_thread_buffer_bytes = 8192
-max_number_of_log_files_on_disk = 10
 
 [tools.simulator]
 random_seed = 0

--- a/src/sample/config.ini
+++ b/src/sample/config.ini
@@ -14,7 +14,6 @@ count = 1
 
 [core]
 ;tool = simulator
-;tool = fastrun
 tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector

--- a/src/server/config-server.ini
+++ b/src/server/config-server.ini
@@ -47,7 +47,6 @@ start_nfs = true
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
-;logging_factory_name = dsn::tools::hpc_logger
 logging_flush_on_exit = true
 
 [block_service.fds_service]
@@ -63,10 +62,6 @@ short_header = false
 fast_flush = false
 max_number_of_log_files_on_disk = 100000
 stderr_start_level = LOG_LEVEL_FATAL
-
-[tools.hpc_logger]
-per_thread_buffer_bytes = 8192
-max_number_of_log_files_on_disk = 100000
 
 [tools.simulator]
 random_seed = 0

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -61,10 +61,6 @@
   max_number_of_log_files_on_disk = 500
   stderr_start_level = LOG_LEVEL_ERROR
 
-[tools.hpc_logger]
-  per_thread_buffer_bytes = 8192
-  max_number_of_log_files_on_disk = 200
-
 [nfs]
   nfs_copy_block_bytes = 4194304
   max_concurrent_remote_copy_requests = 50

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -82,63 +82,54 @@
 [threadpool.THREAD_POOL_DEFAULT]
   name = default
   partitioned = false
-  max_input_queue_length = 1024
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 8
 
 [threadpool.THREAD_POOL_REPLICATION]
   name = replica
   partitioned = true
-  max_input_queue_length = 2048
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 24
 
 [threadpool.THREAD_POOL_META_STATE]
   name = meta_state
   partitioned = true
-  max_input_queue_length = 1024
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 1
 
 [threadpool.THREAD_POOL_DLOCK]
   name = dist_lock
   partitioned = true
-  max_input_queue_length = 1024
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 1
 
 [threadpool.THREAD_POOL_FD]
   name = fd
   partitioned = false
-  max_input_queue_length = 1024
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 2
 
 [threadpool.THREAD_POOL_LOCAL_APP]
   name = local_app
   partitioned = false
-  max_input_queue_length = 2048
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 24
 
 [threadpool.THREAD_POOL_REPLICATION_LONG]
   name = rep_long
   partitioned = false
-  max_input_queue_length = 1024
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 8
 
 [threadpool.THREAD_POOL_FDS_SERVICE]
   name = fds_service
   worker_count = 8
-  max_input_queue_length = 1024
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 8
 
 [threadpool.THREAD_POOL_COMPACT]
   name = compact
   partitioned = false
-  max_input_queue_length = 1024
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 8
 

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -313,7 +313,6 @@
   rpc_call_channel = RPC_CHANNEL_TCP
   rpc_call_header_format = NET_HDR_DSN
   rpc_message_crc_required = false
-  fast_execution_in_network_thread = false
   rpc_call_header_format_name = dsn
   rpc_timeout_milliseconds = 5000
 

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -268,6 +268,7 @@
   checkpoint_reserve_min_count = 2
   checkpoint_reserve_time_seconds = 1800
 
+  update_rdb_stat_interval = 600
 
   manual_compact_min_interval_seconds = 600
 

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -47,7 +47,6 @@
 
   pause_on_start = false
   enable_default_app_mimic = true
-  start_nfs = true
 
   logging_start_level = LOG_LEVEL_DEBUG
   logging_factory_name = dsn::tools::simple_logger
@@ -269,7 +268,6 @@
   checkpoint_reserve_min_count = 2
   checkpoint_reserve_time_seconds = 1800
 
-  updating_rocksdb_sstsize_interval_seconds = 600
 
   manual_compact_min_interval_seconds = 600
 

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -46,8 +46,6 @@
   toollets = profiler
 
   pause_on_start = false
-  cli_local = false
-  cli_remote = true
   enable_default_app_mimic = true
   start_nfs = true
 

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -59,42 +59,36 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 8
 
 [threadpool.THREAD_POOL_REPLICATION]
 name = replica
 partitioned = true
-max_input_queue_length = 2048
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 10
 
 [threadpool.THREAD_POOL_DLOCK]
 name = dist_lock
 partitioned = true
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 1
 
 [threadpool.THREAD_POOL_FD]
 name = fd
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 2
 
 [threadpool.THREAD_POOL_LOCAL_APP]
 name = local_app
 partitioned = false
-max_input_queue_length = 2048
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 8
 
 [threadpool.THREAD_POOL_REPLICATION_LONG]
 name = rep_long
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 4
 

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -22,7 +22,6 @@ toollets = profiler
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = true
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
@@ -188,7 +187,6 @@ max_concurrent_uploading_file_count = 5
 [pegasus.server]
 rocksdb_verbose_log = false
 rocksdb_write_buffer_size = 10485760
-updating_rocksdb_sstsize_interval_seconds = 30
 verify_timetag = true
 
 perf_counter_cluster_name = onebox

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -21,8 +21,6 @@ tool = nativerun
 toollets = profiler
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = true
-cli_remote = true
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = true
 

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -16,7 +16,6 @@ count = 1
 
 [core]
 ;tool = simulator
-;tool = fastrun
 tool = nativerun
 toollets = profiler
 ;toollets = tracer, profiler, fault_injector

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -101,7 +101,6 @@ worker_count = 1
 is_trace = false
 is_profile = false
 allow_inline = false
-fast_execution_in_network_thread = false
 rpc_call_header_format = NET_HDR_DSN
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_timeout_milliseconds = 5000

--- a/src/server/test/config.ini
+++ b/src/server/test/config.ini
@@ -29,7 +29,6 @@ start_nfs = true
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
-;logging_factory_name = dsn::tools::hpc_logger
 logging_flush_on_exit = true
 
 [block_service.fds_service]
@@ -45,10 +44,6 @@ short_header = false
 fast_flush = false
 max_number_of_log_files_on_disk = 100000
 stderr_start_level = LOG_LEVEL_FATAL
-
-[tools.hpc_logger]
-per_thread_buffer_bytes = 8192
-max_number_of_log_files_on_disk = 100000
 
 [tools.simulator]
 random_seed = 0

--- a/src/shell/config.ini
+++ b/src/shell/config.ini
@@ -19,8 +19,6 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/shell/config.ini
+++ b/src/shell/config.ini
@@ -61,7 +61,6 @@ name = meta_server
 is_trace = false
 is_profile = false
 allow_inline = false
-fast_execution_in_network_thread = false
 rpc_call_header_format = NET_HDR_DSN
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_timeout_milliseconds = 10000

--- a/src/shell/config.ini
+++ b/src/shell/config.ini
@@ -21,7 +21,6 @@ tool = nativerun
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger

--- a/src/shell/config.ini
+++ b/src/shell/config.ini
@@ -28,7 +28,6 @@ start_nfs = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
-;logging_factory_name = dsn::tools::hpc_logger
 logging_flush_on_exit = false
 
 enable_default_app_mimic = true
@@ -40,10 +39,6 @@ short_header = false
 fast_flush = true
 max_number_of_log_files_on_disk = 10
 stderr_start_level = LOG_LEVEL_FATAL
-
-[tools.hpc_logger]
-per_thread_buffer_bytes = 8192
-max_number_of_log_files_on_disk = 10
 
 [tools.simulator]
 random_seed = 0

--- a/src/shell/config.ini
+++ b/src/shell/config.ini
@@ -51,7 +51,6 @@ io_service_worker_count = 4
 [threadpool..default]
 worker_count = 4
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 
 [threadpool.THREAD_POOL_DEFAULT]

--- a/src/shell/config.ini
+++ b/src/shell/config.ini
@@ -14,7 +14,6 @@ count = 1
 
 [core]
 ;tool = simulator
-;tool = fastrun
 tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector

--- a/src/test/bench_test/config.ini
+++ b/src/test/bench_test/config.ini
@@ -54,7 +54,6 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 10
 

--- a/src/test/bench_test/config.ini
+++ b/src/test/bench_test/config.ini
@@ -19,8 +19,6 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/test/bench_test/config.ini
+++ b/src/test/bench_test/config.ini
@@ -40,10 +40,6 @@ fast_flush = false
 max_number_of_log_files_on_disk = 10
 stderr_start_level = LOG_LEVEL_FATAL
 
-[tools.hpc_logger]
-per_thread_buffer_bytes = 8192
-max_number_of_log_files_on_disk = 10
-
 [tools.simulator]
 random_seed = 0
 

--- a/src/test/bench_test/config.ini
+++ b/src/test/bench_test/config.ini
@@ -21,7 +21,6 @@ tool = nativerun
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger

--- a/src/test/bench_test/config.ini
+++ b/src/test/bench_test/config.ini
@@ -14,7 +14,6 @@ count = 1
 
 [core]
 ;tool = simulator
-;tool = fastrun
 tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -16,7 +16,6 @@ count = 1
 [core]
 ;tool = simulator
 tool = nativerun
-;tool = fastrun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -57,7 +57,6 @@ is_profile = false
 allow_inline = false
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_call_header_format = NET_HDR_DSN
-fast_execution_in_network_thread = false
 rpc_timeout_milliseconds = 5000
 
 [replication]

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -20,8 +20,6 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -22,7 +22,6 @@ tool = nativerun
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -51,7 +51,6 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 8
 

--- a/src/test/function_test/config.ini
+++ b/src/test/function_test/config.ini
@@ -27,7 +27,6 @@ cli_remote = false
 start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
-;logging_factory_name = dsn::tools::hpc_logger
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
 

--- a/src/test/kill_test/config.ini
+++ b/src/test/kill_test/config.ini
@@ -61,7 +61,6 @@ is_profile = false
 allow_inline = false
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_call_header_format = NET_HDR_DSN
-fast_execution_in_network_thread = false
 rpc_timeout_milliseconds = 5000
 
 [pegasus.killtest]

--- a/src/test/kill_test/config.ini
+++ b/src/test/kill_test/config.ini
@@ -16,7 +16,6 @@ count = 1
 [core]
 ;tool = simulator
 tool = nativerun
-;tool = fastrun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false

--- a/src/test/kill_test/config.ini
+++ b/src/test/kill_test/config.ini
@@ -55,7 +55,6 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 8
 

--- a/src/test/kill_test/config.ini
+++ b/src/test/kill_test/config.ini
@@ -29,7 +29,6 @@ start_nfs = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
-;logging_factory_name = dsn::tools::hpc_logger
 logging_flush_on_exit = true
 
 enable_default_app_mimic = true
@@ -41,10 +40,6 @@ short_header = false
 fast_flush = true
 max_number_of_log_files_on_disk = 1000
 stderr_start_level = LOG_LEVEL_FATAL
-
-[tools.hpc_logger]
-per_thread_buffer_bytes = 8192
-max_number_of_log_files_on_disk = 1000
 
 [tools.simulator]
 random_seed = 0

--- a/src/test/kill_test/config.ini
+++ b/src/test/kill_test/config.ini
@@ -20,8 +20,6 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/test/kill_test/config.ini
+++ b/src/test/kill_test/config.ini
@@ -22,7 +22,6 @@ tool = nativerun
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger

--- a/src/test/upgrade_test/config.ini
+++ b/src/test/upgrade_test/config.ini
@@ -16,7 +16,6 @@ count = 1
 [core]
 ;tool = simulator
 tool = nativerun
-;tool = fastrun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false

--- a/src/test/upgrade_test/config.ini
+++ b/src/test/upgrade_test/config.ini
@@ -55,7 +55,6 @@ worker_count = 4
 [threadpool.THREAD_POOL_DEFAULT]
 name = default
 partitioned = false
-max_input_queue_length = 1024
 worker_priority = THREAD_xPRIORITY_NORMAL
 worker_count = 8
 

--- a/src/test/upgrade_test/config.ini
+++ b/src/test/upgrade_test/config.ini
@@ -29,7 +29,6 @@ start_nfs = false
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger
 ;logging_factory_name = dsn::tools::screen_logger
-;logging_factory_name = dsn::tools::hpc_logger
 logging_flush_on_exit = true
 
 enable_default_app_mimic = true
@@ -41,10 +40,6 @@ short_header = false
 fast_flush = true
 max_number_of_log_files_on_disk = 100000
 stderr_start_level = LOG_LEVEL_FATAL
-
-[tools.hpc_logger]
-per_thread_buffer_bytes = 8192
-max_number_of_log_files_on_disk = 100000
 
 [tools.simulator]
 random_seed = 0

--- a/src/test/upgrade_test/config.ini
+++ b/src/test/upgrade_test/config.ini
@@ -20,8 +20,6 @@ tool = nativerun
 ;toollets = tracer
 ;toollets = tracer, profiler, fault_injector
 pause_on_start = false
-cli_local = false
-cli_remote = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
 start_nfs = false

--- a/src/test/upgrade_test/config.ini
+++ b/src/test/upgrade_test/config.ini
@@ -22,7 +22,6 @@ tool = nativerun
 pause_on_start = false
 
 ;aio_factory_name = dsn::tools::native_aio_provider
-start_nfs = false
 
 logging_start_level = LOG_LEVEL_DEBUG
 logging_factory_name = dsn::tools::simple_logger

--- a/src/test/upgrade_test/config.ini
+++ b/src/test/upgrade_test/config.ini
@@ -61,7 +61,6 @@ is_profile = false
 allow_inline = false
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_call_header_format = NET_HDR_DSN
-fast_execution_in_network_thread = false
 rpc_timeout_milliseconds = 5000
 
 [pegasus.upgradetest]


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

The configurations 
- `max_input_queue_length ` 
- `hpc_logger`
- `cli_local`
- `cli_remote`
- ` updating_rocksdb_sstsize_interval_seconds`
- `start_nfs`
- `fast_execution_in_network_thread`
- `fast_run`

already have no codes related.

Previously @qinzuoyan had cleared `max_input_queue_length ` from rdsn: https://github.com/XiaoMi/rdsn/pull/191
@shengofsun has cleared `cli_local` and `cli_remote` from rdsn: https://github.com/XiaoMi/rdsn/pull/156
@acelyc111 has changed `updating_rocksdb_sstsize_interval_seconds` to `update_rdb_stat_interval` #212
@shengofsun  has cleared `start_nfs` from rdsn: https://github.com/XiaoMi/rdsn/pull/142
@qinzuoyan has cleared `fast_execution_in_network_thread` from rdsn in 2016: https://github.com/XiaoMi/rdsn/commit/2e43e94bb489af286691ed0f6bfdf3997cf10195 

`fast_run` was removed in https://github.com/XiaoMi/rdsn/pull/117

This time I do the same thing in Pegasus.

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Related changes

- Need to update the documentation
