### PR TITLE
server: improve capacity unit calculation

### DIFF
--- a/src/server/config-server.ini
+++ b/src/server/config-server.ini
@@ -291,6 +291,7 @@ app_stat_interval_seconds = 10
 
 cu_stat_app = @APP_NAME@
 cu_fetch_interval_seconds = 8
+st_fetch_interval_seconds = 60
 
 [pegasus.clusters]
 onebox = @LOCAL_IP@:34601,@LOCAL_IP@:34602,@LOCAL_IP@:34603

--- a/src/server/config-server.ini
+++ b/src/server/config-server.ini
@@ -286,7 +286,7 @@ app_stat_interval_seconds = 10
 
 usage_stat_app = @APP_NAME@
 capacity_unit_fetch_interval_seconds = 8
-storage_size_fetch_interval_seconds = 60
+storage_size_fetch_interval_seconds = 3600
 
 [pegasus.clusters]
 onebox = @LOCAL_IP@:34601,@LOCAL_IP@:34602,@LOCAL_IP@:34603

--- a/src/server/config-server.ini
+++ b/src/server/config-server.ini
@@ -284,9 +284,9 @@ available_detect_timeout = 5000
 
 app_stat_interval_seconds = 10
 
-cu_stat_app = @APP_NAME@
-cu_fetch_interval_seconds = 8
-st_fetch_interval_seconds = 60
+usage_stat_app = @APP_NAME@
+capacity_unit_fetch_interval_seconds = 8
+storage_size_fetch_interval_seconds = 60
 
 [pegasus.clusters]
 onebox = @LOCAL_IP@:34601,@LOCAL_IP@:34602,@LOCAL_IP@:34603

--- a/src/server/config-server.ini
+++ b/src/server/config-server.ini
@@ -279,15 +279,17 @@ falcon_path = /v1/push
 
 [pegasus.collector]
 cluster = onebox
+
 available_detect_app = @APP_NAME@
 available_detect_alert_script_dir = ./package/bin
 available_detect_alert_email_address =
 available_detect_interval_seconds = 3
 available_detect_alert_fail_count = 30
 available_detect_timeout = 5000
+
 app_stat_interval_seconds = 10
 
-cu_stat_app = stat
+cu_stat_app = @APP_NAME@
 cu_fetch_interval_seconds = 8
 
 [pegasus.clusters]

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -295,9 +295,9 @@
 
   app_stat_interval_seconds = 10
 
-  cu_stat_app = stat
-  cu_fetch_interval_seconds = 8
-  st_fetch_interval_seconds = 3600
+  usage_stat_app_stat_app = stat
+  capacity_unit_fetch_interval_seconds = 8
+  storage_size_fetch_interval_seconds = 3600
 
 [pegasus.clusters]
   %{cluster.name} = %{meta.server.list}

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -301,12 +301,14 @@
 
 [pegasus.collector]
   cluster = %{cluster.name}
+
   available_detect_app = temp
   available_detect_alert_script_dir = ./package/bin
   available_detect_alert_email_address =
   available_detect_interval_seconds = 3
   available_detect_alert_fail_count = 30
   available_detect_timeout = 5000
+
   app_stat_interval_seconds = 10
 
   cu_stat_app = stat

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -313,6 +313,7 @@
 
   cu_stat_app = stat
   cu_fetch_interval_seconds = 8
+  st_fetch_interval_seconds = 3600
 
 [pegasus.clusters]
   %{cluster.name} = %{meta.server.list}

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -295,7 +295,7 @@
 
   app_stat_interval_seconds = 10
 
-  usage_stat_app_stat_app = stat
+  usage_stat_app = stat
   capacity_unit_fetch_interval_seconds = 8
   storage_size_fetch_interval_seconds = 3600
 

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -25,8 +25,12 @@ namespace pegasus {
 namespace server {
 
 DEFINE_TASK_CODE(LPC_PEGASUS_APP_STAT_TIMER, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
-DEFINE_TASK_CODE(LPC_PEGASUS_CU_STAT_TIMER, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
-DEFINE_TASK_CODE(LPC_PEGASUS_ST_STAT_TIMER, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
+DEFINE_TASK_CODE(LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
+                 TASK_PRIORITY_COMMON,
+                 ::dsn::THREAD_POOL_DEFAULT)
+DEFINE_TASK_CODE(LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
+                 TASK_PRIORITY_COMMON,
+                 ::dsn::THREAD_POOL_DEFAULT)
 
 info_collector::info_collector()
 {
@@ -105,7 +109,7 @@ void info_collector::start()
                                       std::chrono::minutes(1));
 
     _capacity_unit_stat_timer_task = ::dsn::tasking::enqueue_timer(
-        LPC_PEGASUS_CU_STAT_TIMER,
+        LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
         &_tracker,
         [this] { on_capacity_unit_stat(_capacity_unit_retry_max_count); },
         std::chrono::seconds(_capacity_unit_fetch_interval_seconds),
@@ -113,7 +117,7 @@ void info_collector::start()
         std::chrono::minutes(1));
 
     _storage_size_stat_timer_task = ::dsn::tasking::enqueue_timer(
-        LPC_PEGASUS_ST_STAT_TIMER,
+        LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
         &_tracker,
         [this] { on_storage_size_stat(_storage_size_retry_max_count); },
         std::chrono::seconds(_storage_size_fetch_interval_seconds),
@@ -267,7 +271,7 @@ void info_collector::on_capacity_unit_stat(int remaining_retry_count)
                    "wait %u seconds to retry",
                    remaining_retry_count,
                    _capacity_unit_retry_wait_seconds);
-            ::dsn::tasking::enqueue(LPC_PEGASUS_CU_STAT_TIMER,
+            ::dsn::tasking::enqueue(LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
                                     &_tracker,
                                     [=] { on_capacity_unit_stat(remaining_retry_count - 1); },
                                     0,
@@ -314,7 +318,7 @@ void info_collector::on_storage_size_stat(int remaining_retry_count)
                    "wait %u seconds to retry",
                    remaining_retry_count,
                    _storage_size_retry_wait_seconds);
-            ::dsn::tasking::enqueue(LPC_PEGASUS_ST_STAT_TIMER,
+            ::dsn::tasking::enqueue(LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
                                     &_tracker,
                                     [=] { on_storage_size_stat(remaining_retry_count - 1); },
                                     0,

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -271,7 +271,8 @@ void info_collector::on_capacity_unit_stat(int remaining_retry_count)
         return;
     }
     for (node_capacity_unit_stat &elem : nodes_stat) {
-        if (!has_capacity_unit_updated(elem.node_address, elem.timestamp)) {
+        if (elem.node_address.empty() || elem.timestamp.empty() ||
+            !has_capacity_unit_updated(elem.node_address, elem.timestamp)) {
             dinfo("recent read/write capacity unit value of node %s has not updated",
                   elem.node_address.c_str());
             continue;

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -50,20 +50,20 @@ info_collector::info_collector()
                                                                        10, // default value 10s
                                                                        "app stat interval seconds");
 
-    _cu_stat_app = dsn_config_get_value_string(
-        "pegasus.collector", "cu_stat_app", "", "app for recording capacity unit info");
-    dassert(!_cu_stat_app.empty(), "");
+    _usage_stat_app = dsn_config_get_value_string(
+        "pegasus.collector", "usage_stat_app", "", "app for recording usage statistics");
+    dassert(!_usage_stat_app.empty(), "");
     // initialize the _client.
     if (!pegasus_client_factory::initialize(nullptr)) {
         dassert(false, "Initialize the pegasus client failed");
     }
-    _client = pegasus_client_factory::get_client(_cluster_name.c_str(), _cu_stat_app.c_str());
+    _client = pegasus_client_factory::get_client(_cluster_name.c_str(), _usage_stat_app.c_str());
     dassert(_client != nullptr, "Initialize the client failed");
     _result_writer = dsn::make_unique<result_writer>(_client);
 
     _cu_fetch_interval_seconds =
         (uint32_t)dsn_config_get_value_uint64("pegasus.collector",
-                                              "cu_fetch_interval_seconds",
+                                              "capacity_unit_fetch_interval_seconds",
                                               8, // default value 8s
                                               "capacity unit fetch interval seconds");
     _cu_fetch_retry_count = 3;
@@ -71,7 +71,7 @@ info_collector::info_collector()
 
     _st_fetch_interval_seconds =
         (uint32_t)dsn_config_get_value_uint64("pegasus.collector",
-                                              "st_fetch_interval_seconds",
+                                              "storage_size_fetch_interval_seconds",
                                               3600, // default value 1h
                                               "storage size fetch interval seconds");
     _st_fetch_retry_count = 3;

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -267,10 +267,10 @@ void info_collector::on_capacity_unit_stat(int remaining_retry_count)
     std::vector<node_capacity_unit_stat> nodes_stat;
     if (!get_capacity_unit_stat(&_shell_context, nodes_stat)) {
         if (remaining_retry_count > 0) {
-            derror("get capacity unit stat failed, remaining_retry_count = %d, "
-                   "wait %u seconds to retry",
-                   remaining_retry_count,
-                   _capacity_unit_retry_wait_seconds);
+            dwarn("get capacity unit stat failed, remaining_retry_count = %d, "
+                  "wait %u seconds to retry",
+                  remaining_retry_count,
+                  _capacity_unit_retry_wait_seconds);
             ::dsn::tasking::enqueue(LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
                                     &_tracker,
                                     [=] { on_capacity_unit_stat(remaining_retry_count - 1); },
@@ -314,10 +314,10 @@ void info_collector::on_storage_size_stat(int remaining_retry_count)
     app_storage_size_stat st_stat;
     if (!get_storage_size_stat(&_shell_context, st_stat)) {
         if (remaining_retry_count > 0) {
-            derror("get storage size stat failed, remaining_retry_count = %d, "
-                   "wait %u seconds to retry",
-                   remaining_retry_count,
-                   _storage_size_retry_wait_seconds);
+            dwarn("get storage size stat failed, remaining_retry_count = %d, "
+                  "wait %u seconds to retry",
+                  remaining_retry_count,
+                  _storage_size_retry_wait_seconds);
             ::dsn::tasking::enqueue(LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
                                     &_tracker,
                                     [=] { on_storage_size_stat(remaining_retry_count - 1); },

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -66,8 +66,10 @@ public:
     void on_app_stat();
     AppStatCounters *get_app_counters(const std::string &app_name);
 
-    void on_capacity_unit_stat();
+    void on_capacity_unit_stat(int remaining_retry_count);
     bool has_capacity_unit_updated(const std::string &node_address, const std::string &timestamp);
+
+    void on_storage_size_stat(int remaining_retry_count);
 
 private:
     dsn::task_tracker _tracker;
@@ -86,7 +88,13 @@ private:
     // for writing cu stat result
     std::unique_ptr<result_writer> _result_writer;
     uint32_t _cu_fetch_interval_seconds;
+    uint32_t _cu_fetch_retry_count;
+    uint32_t _cu_fetch_retry_wait_seconds;
     ::dsn::task_ptr _cu_stat_timer_task;
+    uint32_t _st_fetch_interval_seconds;
+    uint32_t _st_fetch_retry_count;
+    uint32_t _st_fetch_retry_wait_seconds;
+    ::dsn::task_ptr _st_stat_timer_task;
     ::dsn::utils::ex_lock_nr _cu_update_info_lock;
     // mapping 'node address' --> 'last updated timestamp'
     std::map<std::string, string> _cu_update_info;

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -89,9 +89,11 @@ private:
     std::unique_ptr<result_writer> _result_writer;
     uint32_t _capacity_unit_fetch_interval_seconds;
     uint32_t _capacity_unit_retry_wait_seconds;
+    uint32_t _capacity_unit_retry_max_count;
     ::dsn::task_ptr _capacity_unit_stat_timer_task;
     uint32_t _storage_size_fetch_interval_seconds;
     uint32_t _storage_size_retry_wait_seconds;
+    uint32_t _storage_size_retry_max_count;
     ::dsn::task_ptr _storage_size_stat_timer_task;
     ::dsn::utils::ex_lock_nr _capacity_unit_update_info_lock;
     // mapping 'node address' --> 'last updated timestamp'

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -81,8 +81,8 @@ private:
     ::dsn::utils::ex_lock_nr _app_stat_counter_lock;
     std::map<std::string, AppStatCounters *> _app_stat_counters;
 
-    // app for recording read/write cu.
-    std::string _cu_stat_app;
+    // app for recording usage statistics, including read/write capacity unit and storage size.
+    std::string _usage_stat_app;
     // client to access server.
     pegasus_client *_client;
     // for writing cu stat result

--- a/src/server/info_collector.h
+++ b/src/server/info_collector.h
@@ -87,17 +87,15 @@ private:
     pegasus_client *_client;
     // for writing cu stat result
     std::unique_ptr<result_writer> _result_writer;
-    uint32_t _cu_fetch_interval_seconds;
-    uint32_t _cu_fetch_retry_count;
-    uint32_t _cu_fetch_retry_wait_seconds;
-    ::dsn::task_ptr _cu_stat_timer_task;
-    uint32_t _st_fetch_interval_seconds;
-    uint32_t _st_fetch_retry_count;
-    uint32_t _st_fetch_retry_wait_seconds;
-    ::dsn::task_ptr _st_stat_timer_task;
-    ::dsn::utils::ex_lock_nr _cu_update_info_lock;
+    uint32_t _capacity_unit_fetch_interval_seconds;
+    uint32_t _capacity_unit_retry_wait_seconds;
+    ::dsn::task_ptr _capacity_unit_stat_timer_task;
+    uint32_t _storage_size_fetch_interval_seconds;
+    uint32_t _storage_size_retry_wait_seconds;
+    ::dsn::task_ptr _storage_size_stat_timer_task;
+    ::dsn::utils::ex_lock_nr _capacity_unit_update_info_lock;
     // mapping 'node address' --> 'last updated timestamp'
-    std::map<std::string, string> _cu_update_info;
+    std::map<std::string, string> _capacity_unit_update_info;
 };
 } // namespace server
 } // namespace pegasus

--- a/src/server/result_writer.cpp
+++ b/src/server/result_writer.cpp
@@ -20,13 +20,13 @@ void result_writer::set_result(const std::string &hash_key,
         if (err != PERR_OK) {
             int new_try_count = try_count - 1;
             if (new_try_count > 0) {
-                derror("set_result fail, hash_key = %s, sort_key = %s, value = %s, "
-                       "error = %s, left_try_count = %d, try again after 1 minute",
-                       hash_key.c_str(),
-                       sort_key.c_str(),
-                       value.c_str(),
-                       _client->get_error_string(err),
-                       new_try_count);
+                dwarn("set_result fail, hash_key = %s, sort_key = %s, value = %s, "
+                      "error = %s, left_try_count = %d, try again after 1 minute",
+                      hash_key.c_str(),
+                      sort_key.c_str(),
+                      value.c_str(),
+                      _client->get_error_string(err),
+                      new_try_count);
                 ::dsn::tasking::enqueue(
                     LPC_WRITE_RESULT,
                     &_tracker,

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -667,13 +667,12 @@ get_app_stat(shell_context *sc, const std::string &app_name, std::vector<row_dat
     }
 
     ::dsn::command command;
-    command.cmd = "perf-counters";
+    command.cmd = "perf-counters-by-substr";
     char tmp[256];
-    if (app_name.empty()) {
-        sprintf(tmp, ".*@.*");
-    } else {
-        sprintf(tmp, ".*@%d\\..*", app_info->app_id);
-    }
+    if (app_name.empty())
+        sprintf(tmp, "@");
+    else
+        sprintf(tmp, "@%d.", app_info->app_id);
     command.arguments.emplace_back(tmp);
     std::vector<std::pair<bool, std::string>> results;
     call_remote_command(sc, nodes, command, results);
@@ -760,25 +759,21 @@ struct node_capacity_unit_stat
     // timestamp when node perf_counter_info has updated.
     std::string timestamp;
     std::string node_address;
-    // mapping app_name --> (read_cu, write_cu)
-    std::map<std::string, std::pair<int64_t, int64_t>> cu_value_by_app;
+    // mapping: app_id --> (read_cu, write_cu)
+    std::map<int32_t, std::pair<int64_t, int64_t>> cu_value_by_app;
 
     std::string dump_to_json() const
     {
+        std::map<int32_t, std::vector<int64_t>> cu_values;
+        for (auto kv : cu_value_by_app) {
+            auto &cu_pair = kv.second;
+            if (cu_pair.first != 0 || cu_pair.second != 0)
+                cu_values.emplace(kv.first, std::vector<int64_t>{cu_pair.first, cu_pair.second});
+        }
         std::stringstream out;
         rapidjson::OStreamWrapper wrapper(out);
         dsn::json::JsonWriter writer(wrapper);
-        writer.StartObject();
-        for (const auto &elem : cu_value_by_app) {
-            auto cu_tuple = elem.second;
-            if (cu_tuple.first == 0 && cu_tuple.second == 0)
-                continue;
-            char tuple_str[50];
-            sprintf(tuple_str, "[%ld,%ld]", cu_tuple.first, cu_tuple.second);
-            dsn::json::json_encode(writer, elem.first);
-            dsn::json::json_encode(writer, tuple_str);
-        }
-        writer.EndObject();
+        dsn::json::json_encode(writer, cu_values);
         return out.str();
     }
 };
@@ -786,19 +781,16 @@ struct node_capacity_unit_stat
 inline bool get_capacity_unit_stat(shell_context *sc,
                                    std::vector<node_capacity_unit_stat> &nodes_stat)
 {
-    std::vector<::dsn::app_info> apps;
     std::vector<node_desc> nodes;
-    if (!get_apps_and_nodes(sc, apps, nodes))
+    // at most try two times
+    if (!fill_nodes(sc, "replica-server", nodes) && !fill_nodes(sc, "replica-server", nodes)) {
+        derror("get replica server node list failed");
         return false;
-    std::map<int32_t, std::string> app_name_map;
-    for (auto elem : apps)
-        app_name_map.emplace(elem.app_id, elem.app_name);
+    }
 
     ::dsn::command command;
-    command.cmd = "perf-counters";
-    char tmp[256];
-    sprintf(tmp, ".*\\*recent\\..*\\.cu@.*");
-    command.arguments.emplace_back(tmp);
+    command.cmd = "perf-counters-by-substr";
+    command.arguments.emplace_back(".cu@");
     std::vector<std::pair<bool, std::string>> results;
     call_remote_command(sc, nodes, command, results);
 
@@ -806,32 +798,23 @@ inline bool get_capacity_unit_stat(shell_context *sc,
     for (int i = 0; i < nodes.size(); ++i) {
         dsn::rpc_address node_addr = nodes[i].address;
         dsn::perf_counter_info info;
-        if (!decode_node_perf_counter_info(node_addr, results[i], info))
-            return false;
+        if (!decode_node_perf_counter_info(node_addr, results[i], info)) {
+            // get perf counter from this node failed, ignore it
+            dwarn("decode perf counter from node(%s) failed, just ignore it",
+                  node_addr.to_string());
+            continue;
+        }
         nodes_stat[i].timestamp = info.timestamp_str;
         nodes_stat[i].node_address = node_addr.to_string();
         for (dsn::perf_counter_metric &m : info.counters) {
-            int32_t app_id, partition_index;
+            int32_t app_id, pidx;
             std::string counter_name;
-            bool parse_ret =
-                parse_app_pegasus_perf_counter_name(m.name, app_id, partition_index, counter_name);
-            dassert(parse_ret, "name = %s", m.name.c_str());
-            if (app_name_map.find(app_id) == app_name_map.end())
-                continue;
-            std::string app_name = app_name_map[app_id];
+            bool r = parse_app_pegasus_perf_counter_name(m.name, app_id, pidx, counter_name);
+            dassert(r, "name = %s", m.name.c_str());
             if (counter_name == "recent.read.cu") {
-                if (nodes_stat[i].cu_value_by_app.find(app_name) ==
-                    nodes_stat[i].cu_value_by_app.end()) {
-                    nodes_stat[i].cu_value_by_app.emplace(app_name, std::make_pair(0, 0));
-                }
-                nodes_stat[i].cu_value_by_app[app_name].first += (int64_t)m.value;
-            }
-            if (counter_name == "recent.write.cu") {
-                if (nodes_stat[i].cu_value_by_app.find(app_name) ==
-                    nodes_stat[i].cu_value_by_app.end()) {
-                    nodes_stat[i].cu_value_by_app.emplace(app_name, std::make_pair(0, 0));
-                }
-                nodes_stat[i].cu_value_by_app[app_name].second += (int64_t)m.value;
+                nodes_stat[i].cu_value_by_app[app_id].first += (int64_t)m.value;
+            } else if (counter_name == "recent.write.cu") {
+                nodes_stat[i].cu_value_by_app[app_id].second += (int64_t)m.value;
             }
         }
     }

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -853,7 +853,8 @@ inline bool get_storage_size_stat(shell_context *sc, app_storage_size_stat &st_s
     for (auto &kv : app_partitions) {
         auto &v = kv.second;
         for (auto &c : v) {
-            // use partition_flags to record if this partition's storage size is calculated
+            // use partition_flags to record if this partition's storage size is calculated,
+            // because `app_partitions' is a temporary variable, so we can re-use partition_flags.
             c.partition_flags = 0;
         }
     }

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -765,7 +765,7 @@ struct node_capacity_unit_stat
     std::string dump_to_json() const
     {
         std::map<int32_t, std::vector<int64_t>> values;
-        for (auto kv : cu_value_by_app) {
+        for (auto &kv : cu_value_by_app) {
             auto &pair = kv.second;
             if (pair.first != 0 || pair.second != 0)
                 values.emplace(kv.first, std::vector<int64_t>{pair.first, pair.second});

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -201,9 +201,11 @@ bool app_disk(command_executor *e, shell_context *sc, arguments args)
     }
 
     ::dsn::command command;
-    command.cmd = "perf-counters";
+    command.cmd = "perf-counters-by-prefix";
     char tmp[256];
-    sprintf(tmp, ".*\\*app\\.pegasus\\*disk\\.storage\\.sst.*@%d\\..*", app_id);
+    sprintf(tmp, "replica*app.pegasus*disk.storage.sst(MB)@%d.", app_id);
+    command.arguments.push_back(tmp);
+    sprintf(tmp, "replica*app.pegasus*disk.storage.sst.count@%d.", app_id);
     command.arguments.push_back(tmp);
     std::vector<std::pair<bool, std::string>> results;
     call_remote_command(sc, nodes, command, results);


### PR DESCRIPTION
### What problem does this PR solve?
Current capacity unit calculation (committed in #318) has these problems:
* not robust enough: 
   * if get_apps_and_nodes returns false, then terminate, which may cause CU lost.
     ```
     if (!get_apps_and_nodes(sc, apps, nodes))
         return false;
     ```
     **Solution**: retry for some times after several seconds.
  * if decode_node_perf_counter_info failed for one node, then terminate all, which is not reasonable.
     ``` 
        if (!decode_node_perf_counter_info(node_addr, results[i], info))
            return false;
     ```
     **Solution**: ignore failure nodes.
* stat result is not compact enough:
   * in the old may, the stat result is like:
     ```
     "2019-06-16 20:35:45" : "10.239.35.217:34801" => "{\"temp\":[8,11]}"
     ```
   * in the new way, the stat result is like (using app id instead of app name, and add prefix `cu@` in sort_key to diff with storage size stat):
     ```
     "2019-06-16 20:35:45" : "cu@10.239.35.217:34801" => "{\"1\":[8,11]}"
     ```
     **Advantage**: less space; more accurate, because it is not affected by table rename.
* lack of storage size stat:
    * so we add storage size stat as:
      ```
      "2019-06-17 18:47:15" : "ss" => "{\"1\":[8,8,0],\"2\":[8,8,476]}"
      ```
      the triple is `[app_partition_count, stat_partition_count, storage_size_in_mb]`, where `stat_partition_count` is the count of partitions whose storage is accounted.
* performance:
  * by adding remote command `perf-counters-by-substr`, we use simple sub-string search to replace regex matching, which probably reduces loading pressure of replica-server and gives better performance.

### What is changed and how it works?
As mentioned above

### Check List

Tests

- No code
- Manual test passed