### PR TITLE
scripts: check balance state by total balance count on meta & add checking methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ LOG
 
 .shell-history
 PACKAGE
+config-shell.ini.*
+scripts/py_utils/*.pyc

--- a/scripts/clusters_show.sh
+++ b/scripts/clusters_show.sh
@@ -50,7 +50,7 @@ do
   tmp_file="/tmp/$UID.$PID.pegasus.clusters_status.cluster_info"
   echo "cluster_info" | ./run.sh shell -n $cluster &>$tmp_file
   cluster_info_ok=`grep "succeed" $tmp_file | wc -l`
-  if [ $cluster_info_ok -ne 1 ]; then
+  if [ $cluster_info_ok -ne 0 ]; then
     echo "ERROR: get cluster info failed, refer error to $tmp_file"
     exit 1
   fi
@@ -70,7 +70,7 @@ do
   tmp_file="/tmp/$UID.$PID.pegasus.clusters_status.app_stat"
   echo "app_stat -o $app_stat_result" | ./run.sh shell -n $cluster &>$tmp_file
   app_stat_ok=`grep "succeed" $tmp_file | wc -l`
-  if [ $app_stat_ok -ne 1 ]; then
+  if [ $app_stat_ok -ne 0 ]; then
     echo "ERROR: app stat failed, refer error to $tmp_file"
     exit 1
   fi

--- a/scripts/pegasus_check_clusters.py
+++ b/scripts/pegasus_check_clusters.py
@@ -36,6 +36,8 @@ def main(env, verbose):
     set_global_verbose(verbose)
     clusters = list_pegasus_clusters(pegasus_config_path, env)
     for cluster in clusters:
+        if not cluster.is_valid():
+            continue
         echo("=== " + cluster.name())
         try:
             cluster.print_imbalance_nodes()

--- a/scripts/pegasus_check_clusters.py
+++ b/scripts/pegasus_check_clusters.py
@@ -40,8 +40,10 @@ def main(env, verbose):
             continue
         echo("=== " + cluster.name())
         try:
-            cluster.print_imbalance_nodes()
+            cluster.print_imbalanced_nodes()
             cluster.print_unhealthy_partitions()
+            cluster.print_unsteady_meta_level()
+            cluster.print_inconsistent_server_version()
         except RuntimeError as e:
             echo(str(e), "red")
             return

--- a/scripts/py_utils/lib.py
+++ b/scripts/py_utils/lib.py
@@ -23,7 +23,7 @@ def echo(message, color=None):
 class PegasusCluster(object):
     def __init__(self, cfg_file_name):
         self._cluster_name = os.path.basename(cfg_file_name).replace(
-            "pegasus-", "").replace(".cfg", "")
+            "pegasus-", "").replace(".cfg", "").replace(".yaml", "")
         self._shell_path = os.getenv("PEGASUS_SHELL_PATH")
         self._cfg_file_name = cfg_file_name
         if self._shell_path is None:
@@ -74,6 +74,13 @@ class PegasusCluster(object):
                 if line.strip().startswith("host.0"):
                     return line.split("=")[1].strip()
 
+    def is_valid(self):
+        try:
+            try_ls = self._run_shell("ls").strip()
+        except Exception:
+            return False
+        return not "error=ERR_NETWORK_FAILURE" in try_ls
+
     def _run_shell(self, args):
         """
         :param args: arguments passed to ./run.sh shell (type `string`)
@@ -114,7 +121,7 @@ def list_pegasus_clusters(config_path, env):
             continue
         if not fname.startswith("pegasus-" + env):
             continue
-        if not fname.endswith(".cfg"):
+        if not fname.endswith(".cfg") and not fname.endswith(".yaml"):
             continue
         if fname.endswith("proxy.cfg"):
             continue

--- a/scripts/py_utils/lib.py
+++ b/scripts/py_utils/lib.py
@@ -36,8 +36,10 @@ class PegasusCluster(object):
         list_detail = self._run_shell("ls -d -j").strip()
 
         list_detail_json = json.loads(list_detail)
-        read_unhealthy_app_count = int(list_detail_json["summary"]["read_unhealthy_app_count"])
-        write_unhealthy_app_count = int(list_detail_json["summary"]["write_unhealthy_app_count"])
+        read_unhealthy_app_count = int(
+            list_detail_json["summary"]["read_unhealthy_app_count"])
+        write_unhealthy_app_count = int(
+            list_detail_json["summary"]["write_unhealthy_app_count"])
         if write_unhealthy_app_count > 0:
             echo("cluster is write unhealthy, write_unhealthy_app_count = " +
                  str(write_unhealthy_app_count))
@@ -48,17 +50,16 @@ class PegasusCluster(object):
             return
 
     def print_imbalance_nodes(self):
+        cluster_info = json.loads(self._run_shell("cluster_info -j").strip())
         nodes_detail = self._run_shell("nodes -d -j").strip()
+        balance_operation_count = cluster_info["cluster_info"]["balance_operation_count"]
+        total_cnt = int(balance_operation_count.split(',')[3].split('=')[1])
 
         primaries_per_node = {}
-        min_ = 0
-        max_ = 0
         for ip_port, node_info in json.loads(nodes_detail)["details"].items():
             primary_count = int(node_info["primary_count"])
-            min_ = min(min_, primary_count)
-            max_ = max(max_, primary_count)
             primaries_per_node[ip_port] = primary_count
-        if float(min_) / float(max_) < 0.8:
+        if total_cnt != 0:
             print json.dumps(primaries_per_node, indent=4)
 
     def get_meta_port(self):


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
 
1. We used to check the imbalanced state by identifying if the primaries on each node are equal.
That's not accurate since in some cases the meta server may still see the cluster a balanced state while
the nodes are not equally serving replicas.
Now we use "balance_operation_count"  from "cluster_info" command to check the imbalance.

2. Add more cluster checking approaches, like "server version inconsistency", and "unsteady meta level".

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test
