### PR TITLE
scripts: add convenience script for creating table

### DIFF
--- a/scripts/create_table.py
+++ b/scripts/create_table.py
@@ -43,6 +43,7 @@ import click
 import py_utils
 import re
 import json
+import math
 
 
 def validate_param_table(ctx, param, value):
@@ -63,10 +64,11 @@ def validate_param_cluster(ctx, param, value):
 
 
 def validate_param_partition_count(ctx, param, value):
-    # TODO(wutao1): ensure partition count is a power of 2
     if value == 0:
-        py_utils.echo("Cannot create table with 0 partition", "red")
-        return
+        raise click.BadParameter("Cannot create table with 0 partition")
+    if math.log(value, 2) != math.floor(math.log(value, 2)):
+        raise click.BadParameter(
+            "Partition count {} should be a power of 2".format(value))
     return value
 
 

--- a/scripts/create_table.py
+++ b/scripts/create_table.py
@@ -71,23 +71,6 @@ def create_table_if_needed(cluster, table, parts):
 
 
 def set_business_info_if_needed(cluster, table, depart, user):
-    envs = cluster.get_app_envs(table)
-    new_business_info = "depart={},user={}".format(depart, user)
-    py_utils.echo("New value of business.info=" + envs['business.info'])
-
-    if envs != None:
-        py_utils.echo("Old value of business.info=" + envs['business.info'])
-        business_info = envs['business.info'].split(',')
-        (d, u) = (business_info[0].encode('utf8')[
-            len('depart='):], business_info[1].encode('utf8')[len('user='):])
-        if d == depart and u == user:
-            py_utils.echo("Success: business info has been set already")
-            return
-    cluster.set_app_envs(table, 'business.info',
-                         new_business_info)
-
-
-def set_business_info_if_needed(cluster, table, depart, user):
     new_business_info = "depart={},user={}".format(depart, user)
     py_utils.echo("New value of business.info=" + new_business_info)
 

--- a/scripts/create_table.py
+++ b/scripts/create_table.py
@@ -82,12 +82,12 @@ def validate_param_write_throttling(ctx, param, value):
             'invalid value of throttle \'%s\'' % value)
 
 
-def create_table_if_needed(cluster, table, parts):
+def create_table_if_needed(cluster, table, partition_count):
     if not cluster.has_table(table):
         try:
             # TODO(wutao1): Outputs progress while polling.
             py_utils.echo("Creating table {}...".format(table))
-            cluster.create_table(table, parts)
+            cluster.create_table(table, partition_count)
         except Exception as err:
             py_utils.echo(err, "red")
             exit(1)
@@ -111,11 +111,11 @@ def set_app_envs_if_needed(cluster, table, env_name, new_env_value):
     py_utils.echo("New value of {}={}".format(env_name, new_env_value))
     envs = cluster.get_app_envs(table)
     if envs is not None:
-        old_env_value = envs.get(env_name)
+        old_env_value = envs.get(env_name).encode('utf-8')
         if old_env_value is not None:
             py_utils.echo("Old value of {}={}".format(env_name, old_env_value))
             if old_env_value == new_env_value:
-                py_utils.echo("Success: {} keeps unchanged", env_name)
+                py_utils.echo("Success: {} keeps unchanged".format(env_name))
                 return
     cluster.set_app_envs(table, env_name,
                          new_env_value)

--- a/scripts/create_table.py
+++ b/scripts/create_table.py
@@ -1,0 +1,158 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Xiaomi, Inc.  All rights reserved.
+# This source code is licensed under the Apache License Version 2.0, which
+# can be found in the LICENSE file in the root directory of this source tree.
+
+"""
+Basic usage:
+
+./scripts/create_table.py --table ai_user_info --depart 人工智能部-小爱-XXX项目组 --user wutao1 --cluster bj1-ai --throttle "2000*delay*100" --parts 16
+
+TODO: automatically set write throttling on the table.
+"""
+
+import os
+import click
+import py_utils
+import re
+
+
+def validate_param_table(ctx, param, value):
+    # TODO(wutao1): check illegal characters
+    return value
+
+
+def validate_param_depart(ctx, param, value):
+    return value.encode('utf-8')
+
+
+def validate_param_user(ctx, param, value):
+    return value.encode('utf-8')
+
+
+def validate_param_cluster(ctx, param, value):
+    return value
+
+
+def validate_param_parts(ctx, param, value):
+    if value == None:
+        return
+    try:
+        parts = int(value)
+        return parts
+    except ValueError:
+        raise click.BadParameter(
+            'invalid value of partition count \'%s\'' % value)
+
+
+def validate_param_throttle(ctx, param, value):
+    if value == '':
+        return None
+    pattern = re.compile(r'^\d+\*delay\*\d+(,\d+\*reject\*\d+)?$')
+    match = pattern.match(value)
+    if match is not None:
+        return value
+    else:
+        raise click.BadParameter(
+            'invalid value of throttle \'%s\'' % value)
+
+
+def create_table_if_needed(cluster, table, parts):
+    if not cluster.has_table(table):
+        try:
+            cluster.create_table(table, parts)
+        except Exception as err:
+            py_utils.echo(err, "red")
+            exit(1)
+    else:
+        py_utils.echo("Success: table \"{}\" exists".format(table))
+
+
+def set_business_info_if_needed(cluster, table, depart, user):
+    envs = cluster.get_app_envs(table)
+    new_business_info = "depart={},user={}".format(depart, user)
+    py_utils.echo("New value of business.info=" + envs['business.info'])
+
+    if envs != None:
+        py_utils.echo("Old value of business.info=" + envs['business.info'])
+        business_info = envs['business.info'].split(',')
+        (d, u) = (business_info[0].encode('utf8')[
+            len('depart='):], business_info[1].encode('utf8')[len('user='):])
+        if d == depart and u == user:
+            py_utils.echo("Success: business info has been set already")
+            return
+    cluster.set_app_envs(table, 'business.info',
+                         new_business_info)
+
+
+def set_business_info_if_needed(cluster, table, depart, user):
+    new_business_info = "depart={},user={}".format(depart, user)
+    py_utils.echo("New value of business.info=" + new_business_info)
+
+    envs = cluster.get_app_envs(table)
+    if envs != None:
+        old_business_info = envs.get('business.info')
+        if old_business_info != None:
+            py_utils.echo("Old value of business.info=" + old_business_info)
+            if old_business_info.encode('utf-8') == new_business_info:
+                py_utils.echo("Success: business info keeps unchanged")
+                return
+
+    cluster.set_app_envs(table, 'business.info',
+                         new_business_info)
+
+
+def set_write_throttling_if_needed(cluster, table, new_throttle):
+    py_utils.echo("New value of replica.write_throttling=" + new_throttle)
+
+    envs = cluster.get_app_envs(table)
+    if envs != None:
+        old_throttle = envs.get('replica.write_throttling')
+        if old_throttle != None:
+            py_utils.echo(
+                "Old value of replica.write_throttling=" + old_throttle)
+            if old_throttle == new_throttle:
+                py_utils.echo(
+                    "Success: throttle keeps unchanged")
+                return
+    cluster.set_app_envs(table, 'replica.write_throttling',
+                         new_throttle)
+
+
+@click.command()
+@click.option("--table",
+              required=True,
+              callback=validate_param_table,
+              help="Name of the table you want to create.")
+@click.option("--depart",
+              required=True,
+              callback=validate_param_depart,
+              help="Department of the table owner. If there are more than one levels of department, use '-' to concatenate them")
+@click.option("--user",
+              required=True,
+              callback=validate_param_user,
+              help="The table owner. If there are more than one owners, use '&' to concatenate them.")
+@click.option("--cluster",
+              required=True,
+              callback=validate_param_cluster,
+              help="The cluster name. Where you want to place the table.")
+@click.option("--parts",
+              callback=validate_param_parts,
+              help="The partition count of the table. Empty means no create.")
+@click.option("--throttle",
+              default="",
+              callback=validate_param_throttle,
+              help="{delay_qps_threshold}*delay*{delay_ms},{reject_qps_threshold}*reject*{delay_ms_before_reject}")
+def main(table, depart, user, cluster, parts, throttle):
+    c = py_utils.PegasusCluster(cluster_name=cluster)
+    create_table_if_needed(c, table, parts)
+    set_business_info_if_needed(c, table, depart, user)
+    if throttle is not None:
+        set_write_throttling_if_needed(c, table, throttle)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/create_table.py
+++ b/scripts/create_table.py
@@ -6,22 +6,48 @@
 # can be found in the LICENSE file in the root directory of this source tree.
 
 """
-Basic usage:
+HOWTO
+=====
 
-./scripts/create_table.py --table ai_user_info --depart 人工智能部-小爱-XXX项目组 --user wutao1 --cluster bj1-ai --throttle "2000*delay*100" --parts 16
+./scripts/create_table.py --table ai_user_info \
+                          --depart 云平台部-存储平台-KV系统组 \
+                          --user wutao1&qinzuoyan \
+                          --cluster bj1-ai \
+                          --write_throttling "2000*delay*100" \
+                          --partition_count 16
 
-TODO: automatically set write throttling on the table.
+OR
+
+./scripts/create_table.py -t ai_user_info \
+                          -d 云平台部-存储平台-KV系统组 \
+                          -u wutao1&qinzuoyan \
+                          -c bj1-ai \
+                          -w "2000*delay*100" \
+                          -p 16
+
+DEVLOPER GUIDE
+==============
+
+The source code is formatted using autopep8.
+Ensure you have run formatter before committing changes.
+```
+autopep8 -i --aggressive --aggressive scripts/create_table.py
+```
+
+TODO(wutao1): automatically set write throttling according to the given
+              estimated QPS on the table.
 """
 
 import os
 import click
 import py_utils
 import re
+import json
 
 
 def validate_param_table(ctx, param, value):
     # TODO(wutao1): check illegal characters
-    return value
+    return value.encode('utf-8')
 
 
 def validate_param_depart(ctx, param, value):
@@ -33,27 +59,24 @@ def validate_param_user(ctx, param, value):
 
 
 def validate_param_cluster(ctx, param, value):
+    return value.encode('utf-8')
+
+
+def validate_param_partition_count(ctx, param, value):
+    # TODO(wutao1): ensure partition count is a power of 2
+    if value == 0:
+        py_utils.echo("Cannot create table with 0 partition", "red")
+        return
     return value
 
 
-def validate_param_parts(ctx, param, value):
-    if value == None:
-        return
-    try:
-        parts = int(value)
-        return parts
-    except ValueError:
-        raise click.BadParameter(
-            'invalid value of partition count \'%s\'' % value)
-
-
-def validate_param_throttle(ctx, param, value):
+def validate_param_write_throttling(ctx, param, value):
     if value == '':
         return None
     pattern = re.compile(r'^\d+\*delay\*\d+(,\d+\*reject\*\d+)?$')
     match = pattern.match(value)
     if match is not None:
-        return value
+        return value.encode('utf-8')
     else:
         raise click.BadParameter(
             'invalid value of throttle \'%s\'' % value)
@@ -62,6 +85,8 @@ def validate_param_throttle(ctx, param, value):
 def create_table_if_needed(cluster, table, parts):
     if not cluster.has_table(table):
         try:
+            # TODO(wutao1): Outputs progress while polling.
+            py_utils.echo("Creating table {}...".format(table))
             cluster.create_table(table, parts)
         except Exception as err:
             py_utils.echo(err, "red")
@@ -72,70 +97,91 @@ def create_table_if_needed(cluster, table, parts):
 
 def set_business_info_if_needed(cluster, table, depart, user):
     new_business_info = "depart={},user={}".format(depart, user)
-    py_utils.echo("New value of business.info=" + new_business_info)
-
-    envs = cluster.get_app_envs(table)
-    if envs != None:
-        old_business_info = envs.get('business.info')
-        if old_business_info != None:
-            py_utils.echo("Old value of business.info=" + old_business_info)
-            if old_business_info.encode('utf-8') == new_business_info:
-                py_utils.echo("Success: business info keeps unchanged")
-                return
-
-    cluster.set_app_envs(table, 'business.info',
-                         new_business_info)
+    set_app_envs_if_needed(cluster, table, 'business.info', new_business_info)
 
 
 def set_write_throttling_if_needed(cluster, table, new_throttle):
-    py_utils.echo("New value of replica.write_throttling=" + new_throttle)
+    if new_throttle is None:
+        return
+    set_app_envs_if_needed(
+        cluster, table, 'replica.write_throttling', new_throttle)
 
+
+def set_app_envs_if_needed(cluster, table, env_name, new_env_value):
+    py_utils.echo("New value of {}={}".format(env_name, new_env_value))
     envs = cluster.get_app_envs(table)
-    if envs != None:
-        old_throttle = envs.get('replica.write_throttling')
-        if old_throttle != None:
-            py_utils.echo(
-                "Old value of replica.write_throttling=" + old_throttle)
-            if old_throttle == new_throttle:
-                py_utils.echo(
-                    "Success: throttle keeps unchanged")
+    if envs is not None:
+        old_env_value = envs.get(env_name)
+        if old_env_value is not None:
+            py_utils.echo("Old value of {}={}".format(env_name, old_env_value))
+            if old_env_value == new_env_value:
+                py_utils.echo("Success: {} keeps unchanged", env_name)
                 return
-    cluster.set_app_envs(table, 'replica.write_throttling',
-                         new_throttle)
+    cluster.set_app_envs(table, env_name,
+                         new_env_value)
+
+
+def all_arguments_to_string(
+        table,
+        depart,
+        user,
+        cluster,
+        partition_count,
+        write_throttling):
+    return json.dumps({
+        'table': table,
+        'depart': depart,
+        'user': user,
+        'cluster': cluster,
+        'partition_count': partition_count,
+        'write_throttling': write_throttling,
+    }, sort_keys=True, indent=4, ensure_ascii=False, encoding='utf-8')
 
 
 @click.command()
-@click.option("--table",
+@click.option("--table", "-t",
               required=True,
               callback=validate_param_table,
               help="Name of the table you want to create.")
-@click.option("--depart",
-              required=True,
-              callback=validate_param_depart,
-              help="Department of the table owner. If there are more than one levels of department, use '-' to concatenate them")
-@click.option("--user",
-              required=True,
-              callback=validate_param_user,
-              help="The table owner. If there are more than one owners, use '&' to concatenate them.")
-@click.option("--cluster",
+@click.option(
+    "--depart", "-d",
+    required=True,
+    callback=validate_param_depart,
+    help="Department of the table owner. If there are more than one levels of department, use '-' to concatenate them.")
+@click.option(
+    "--user", "-u",
+    required=True,
+    callback=validate_param_user,
+    help="The table owner. If there are more than one owners, use '&' to concatenate them.")
+@click.option("--cluster", "-c",
               required=True,
               callback=validate_param_cluster,
               help="The cluster name. Where you want to place the table.")
-@click.option("--parts",
-              callback=validate_param_parts,
-              help="The partition count of the table. Empty means no create.")
-@click.option("--throttle",
-              default="",
-              callback=validate_param_throttle,
-              help="{delay_qps_threshold}*delay*{delay_ms},{reject_qps_threshold}*reject*{delay_ms_before_reject}")
-def main(table, depart, user, cluster, parts, throttle):
+@click.option("--partition_count", "-p",
+              callback=validate_param_partition_count,
+              help="The partition count of the table. Empty means no create.",
+              type=int)
+@click.option(
+    "--write_throttling", "-w",
+    default="",
+    callback=validate_param_write_throttling,
+    help="{delay_qps_threshold}*delay*{delay_ms},{reject_qps_threshold}*reject*{delay_ms_before_reject}")
+def main(table, depart, user, cluster, partition_count, write_throttling):
+    if not click.confirm(
+        "Confirm to create table:\n{}\n".format(
+            all_arguments_to_string(
+            table,
+            depart,
+            user,
+            cluster,
+            partition_count,
+            write_throttling))):
+        return
     c = py_utils.PegasusCluster(cluster_name=cluster)
-    create_table_if_needed(c, table, parts)
+    create_table_if_needed(c, table, partition_count)
     set_business_info_if_needed(c, table, depart, user)
-    if throttle is not None:
-        set_write_throttling_if_needed(c, table, throttle)
+    set_write_throttling_if_needed(c, table, write_throttling)
 
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/py_utils/lib.py
+++ b/scripts/py_utils/lib.py
@@ -21,9 +21,12 @@ def echo(message, color=None):
 
 
 class PegasusCluster(object):
-    def __init__(self, cfg_file_name):
-        self._cluster_name = os.path.basename(cfg_file_name).replace(
-            "pegasus-", "").replace(".cfg", "")
+    def __init__(self, cfg_file_name=None, cluster_name=None):
+        if cluster_name is None:
+            self._cluster_name = os.path.basename(cfg_file_name).replace(
+                "pegasus-", "").replace(".cfg", "")
+        else:
+            self._cluster_name = cluster_name
         self._shell_path = os.getenv("PEGASUS_SHELL_PATH")
         self._cfg_file_name = cfg_file_name
         if self._shell_path is None:
@@ -36,8 +39,10 @@ class PegasusCluster(object):
         list_detail = self._run_shell("ls -d -j").strip()
 
         list_detail_json = json.loads(list_detail)
-        read_unhealthy_app_count = int(list_detail_json["summary"]["read_unhealthy_app_count"])
-        write_unhealthy_app_count = int(list_detail_json["summary"]["write_unhealthy_app_count"])
+        read_unhealthy_app_count = int(
+            list_detail_json["summary"]["read_unhealthy_app_count"])
+        write_unhealthy_app_count = int(
+            list_detail_json["summary"]["write_unhealthy_app_count"])
         if write_unhealthy_app_count > 0:
             echo("cluster is write unhealthy, write_unhealthy_app_count = " +
                  str(write_unhealthy_app_count))
@@ -73,6 +78,33 @@ class PegasusCluster(object):
                 if line.strip().startswith("host.0"):
                     return line.split("=")[1].strip()
 
+    def create_table(self, table, parts):
+        create_result = self._run_shell(
+            "create {} -p {}".format(table, parts)).strip()
+        if "ERR_INVALID_PARAMETERS" in create_result:
+            raise ValueError("failed to create table \"{}\"".format(table))
+
+    def get_app_envs(self, table):
+        envs_result = self._run_shell(
+            "use {} \n get_app_envs".format(table)).strip()[len("OK\n"):]
+        if "ERR_OBJECT_NOT_FOUND" in envs_result:
+            raise ValueError("table {} does not exist".format(table))
+        if envs_result == "":
+            return None
+        envs_result = self._run_shell(
+            "use {} \n get_app_envs -j".format(table)).strip()[len("OK\n"):]
+        return json.loads(envs_result)['app_envs']
+
+    def set_app_envs(self, table, env_name, env_value):
+        envs_result = self._run_shell(
+            "use {} \n set_app_envs {} {}".format(table, env_name, env_value)).strip()[len("OK\n"):]
+        if "ERR_OBJECT_NOT_FOUND" in envs_result:
+            raise ValueError("table {} does not exist".format(table))
+
+    def has_table(self, table):
+        app_result = self._run_shell("app {} ".format(table)).strip()
+        return "ERR_OBJECT_NOT_FOUND" not in app_result
+
     def _run_shell(self, args):
         """
         :param args: arguments passed to ./run.sh shell (type `string`)
@@ -80,7 +112,7 @@ class PegasusCluster(object):
         """
         global _global_verbose
 
-        cmd = "cd {1}; echo {0} | ./run.sh shell -n {2}".format(
+        cmd = "cd {1}; echo -e \"{0}\" | ./run.sh shell -n {2}".format(
             args, self._shell_path, self._cluster_name)
         if _global_verbose:
             echo("executing command: \"{0}\"".format(cmd))
@@ -119,3 +151,4 @@ def list_pegasus_clusters(config_path, env):
             continue
         clusters.append(PegasusCluster(config_path + "/" + fname))
     return clusters
+

--- a/scripts/py_utils/lib.py
+++ b/scripts/py_utils/lib.py
@@ -97,7 +97,9 @@ class PegasusCluster(object):
 
     def set_app_envs(self, table, env_name, env_value):
         envs_result = self._run_shell(
-            "use {} \n set_app_envs {} {}".format(table, env_name, env_value)).strip()[len("OK\n"):]
+            "use {} \n set_app_envs {} {}".format(
+                table, env_name, env_value)).strip()[
+            len("OK\n"):]
         if "ERR_OBJECT_NOT_FOUND" in envs_result:
             raise ValueError("table {} does not exist".format(table))
 
@@ -151,4 +153,3 @@ def list_pegasus_clusters(config_path, env):
             continue
         clusters.append(PegasusCluster(config_path + "/" + fname))
     return clusters
-


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Add convenience script for creating tables. Users can specify the table owners and their department, the write throttling, as well as the required attributes like 'partition count' and 'table name'.

If the table is created before, users can still reset the table's environments.

This script is at an early stage.

### What is changed and how it works?

I use python for this script, reusing the utilities provided by py_utils/lib.py.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```
➜  pegasus git:(create) ✗ ./scripts/create_table.py -t ai_user_info \
                          -d "云平台部-存储平台-KV系统组" \
                          -u "wutao1&qinzuoyan" \
                          -c c3tst-dup2 \
                          -w "2000*delay*100" \
                          -p 16
Confirm to create table:
{
    "cluster": "c3tst-dup2", 
    "depart": "云平台部-存储平台-KV系统组", 
    "partition_count": 16, 
    "table": "ai_user_info", 
    "user": "wutao1&qinzuoyan", 
    "write_throttling": "2000*delay*100"
}
 [y/N]: y
Creating table ai_user_info...
New value of business.info=depart=云平台部-存储平台-KV系统组,user=wutao1&qinzuoyan
New value of replica.write_throttling=2000*delay*100
```

```
➜  pegasus git:(create) ✗ ./scripts/create_table.py -t ai_user_info \
                          -d "云平台部-存储平台-KV系统组" \
                          -u "wutao1&qinzuoyan" \
                          -c c3tst-dup2 \
                          -w "2000*delay*100" \
                          -p 16
Confirm to create table:
{
    "cluster": "c3tst-dup2", 
    "depart": "云平台部-存储平台-KV系统组", 
    "partition_count": 16, 
    "table": "ai_user_info", 
    "user": "wutao1&qinzuoyan", 
    "write_throttling": "2000*delay*100"
}
 [y/N]: y
Success: table "ai_user_info" exists
New value of business.info=depart=云平台部-存储平台-KV系统组,user=wutao1&qinzuoyan
Old value of business.info=depart=云平台部-存储平台-KV系统组,user=wutao1&qinzuoyan
Success: business.info keeps unchanged
New value of replica.write_throttling=2000*delay*100
Old value of replica.write_throttling=2000*delay*100
Success: replica.write_throttling keeps unchanged
```

```
➜  pegasus git:(create) ✗ ./scripts/create_table.py --help
Usage: create_table.py [OPTIONS]

Options:
  -t, --table TEXT               Name of the table you want to create.
                                 [required]
  -d, --depart TEXT              Department of the table owner. If there are
                                 more than one levels of department, use '-'
                                 to concatenate them.  [required]
  -u, --user TEXT                The table owner. If there are more than one
                                 owners, use '&' to concatenate them.
                                 [required]
  -c, --cluster TEXT             The cluster name. Where you want to place the
                                 table.  [required]
  -p, --partition_count INTEGER  The partition count of the table. Empty means
                                 no create.
  -w, --write_throttling TEXT    {delay_qps_threshold}*delay*{delay_ms},{rejec
                                 t_qps_threshold}*reject*{delay_ms_before_reje
                                 ct}
  --help                         Show this message and exit.
```

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
