### PR TITLE
GEO: Support more configuration for geo_client

### DIFF
--- a/src/geo/bench/bench.cpp
+++ b/src/geo/bench/bench.cpp
@@ -11,6 +11,7 @@
 #include <monitoring/histogram.h>
 #include <rocksdb/env.h>
 
+#include <dsn/utility/errors.h>
 #include <dsn/utility/strings.h>
 #include <dsn/utility/string_conv.h>
 
@@ -44,12 +45,9 @@ int main(int argc, char **argv)
         return -1;
     }
 
-    pegasus::geo::geo_client my_geo("config.ini",
-                                    cluster_name.c_str(),
-                                    app_name.c_str(),
-                                    geo_app_name.c_str(),
-                                    new pegasus::geo::latlng_extractor_for_lbs());
-    if (!my_geo.set_max_level(max_level)) {
+    pegasus::geo::geo_client my_geo(
+        "config.ini", cluster_name.c_str(), app_name.c_str(), geo_app_name.c_str());
+    if (!my_geo.set_max_level(max_level).is_ok()) {
         std::cerr << "set_max_level failed" << std::endl;
         return -1;
     }

--- a/src/geo/bench/bench.cpp
+++ b/src/geo/bench/bench.cpp
@@ -43,12 +43,16 @@ int main(int argc, char **argv)
         std::cerr << "max_level is invalid: " << argv[6] << std::endl;
         return -1;
     }
+
     pegasus::geo::geo_client my_geo("config.ini",
                                     cluster_name.c_str(),
                                     app_name.c_str(),
                                     geo_app_name.c_str(),
                                     new pegasus::geo::latlng_extractor_for_lbs());
-    my_geo.set_max_level(max_level);
+    if (!my_geo.set_max_level(max_level)) {
+        std::cerr << "set_max_level failed" << std::endl;
+        return -1;
+    }
 
     // cover beijing 5th ring road
     S2LatLngRect rect(S2LatLng::FromDegrees(39.810151, 116.194511),

--- a/src/geo/bench/config.ini
+++ b/src/geo/bench/config.ini
@@ -68,3 +68,5 @@ onebox = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
 ;NOTE: 'min_level' is immutable after some data has been inserted into DB by geo_client.
 min_level = 12
 max_level = 16
+latitude_index = 5
+longitude_index = 4

--- a/src/geo/bench/config.ini
+++ b/src/geo/bench/config.ini
@@ -61,10 +61,9 @@ rpc_call_header_format = NET_HDR_DSN
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_timeout_milliseconds = 5000
 
-[uri-resolver.dsn://onebox]
-factory = partition_resolver_simple
-arguments = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
+[pegasus.clusters]
+onebox = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
 
 [geo_client.lib]
 max_level = 16
-
+min_level = 12

--- a/src/geo/bench/config.ini
+++ b/src/geo/bench/config.ini
@@ -65,5 +65,6 @@ rpc_timeout_milliseconds = 5000
 onebox = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
 
 [geo_client.lib]
-max_level = 16
+;NOTE: 'min_level' is immutable after some data has been inserted into DB by geo_client.
 min_level = 12
+max_level = 16

--- a/src/geo/lib/geo_client.cpp
+++ b/src/geo/lib/geo_client.cpp
@@ -63,7 +63,7 @@ geo_client::geo_client(const char *config_file,
     uint32_t longitude_index = (uint32_t)dsn_config_get_value_uint64(
         "geo_client.lib", "longitude_index", 4, "longitude index in value");
 
-    dsn::error_s s = _extractor.set_latlng_indices(std::make_pair(latitude_index, longitude_index));
+    dsn::error_s s = _extractor.set_latlng_indices(latitude_index, longitude_index);
     dassert_f(s.is_ok(), "set_latlng_indices({}, {}) failed", latitude_index, longitude_index);
 }
 

--- a/src/geo/lib/geo_client.h
+++ b/src/geo/lib/geo_client.h
@@ -12,6 +12,10 @@
 #include <pegasus/client.h>
 #include "latlng_extractor.h"
 
+namespace dsn {
+class error_s;
+} // namespace dsn
+
 namespace pegasus {
 namespace geo {
 
@@ -79,8 +83,7 @@ public:
     geo_client(const char *config_file,
                const char *cluster_name,
                const char *common_app_name,
-               const char *geo_app_name,
-               latlng_extractor *extractor);
+               const char *geo_app_name);
 
     ~geo_client() { _tracker.wait_outstanding_tasks(); }
 
@@ -285,7 +288,7 @@ public:
         return _common_data_client->get_error_string(error_code);
     }
 
-    bool set_max_level(int level);
+    dsn::error_s set_max_level(int level);
 
 private:
     friend class geo_client_test;
@@ -405,7 +408,7 @@ private:
 
     dsn::task_tracker _tracker;
 
-    std::shared_ptr<const latlng_extractor> _extractor = nullptr;
+    latlng_extractor _extractor;
     pegasus_client *_common_data_client = nullptr;
     pegasus_client *_geo_data_client = nullptr;
 };

--- a/src/geo/lib/geo_client.h
+++ b/src/geo/lib/geo_client.h
@@ -285,7 +285,7 @@ public:
         return _common_data_client->get_error_string(error_code);
     }
 
-    void set_max_level(int level) { _max_level = level; }
+    bool set_max_level(int level);
 
 private:
     friend class geo_client_test;
@@ -394,14 +394,14 @@ private:
 private:
     // cell id at this level is the hash-key in pegasus
     // `_min_level` is immutable after geo_client data has been inserted into DB.
-    const int _min_level = 12; // edge length at level 12 is about 2km
+    int _min_level = 12; // edge length at level 12 is about 2km
 
     // cell id at this level is the prefix of sort-key in pegasus, and
     // it's convenient for scan operation
     // `_max_level` is mutable at any time, and geo_client-lib users can change it to a appropriate
     // value
     // to improve performance in their scenario.
-    int _max_level = 16;
+    int _max_level = 16; // edge length at level 16 is about 150m
 
     dsn::task_tracker _tracker;
 

--- a/src/geo/lib/latlng_extractor.cpp
+++ b/src/geo/lib/latlng_extractor.cpp
@@ -59,16 +59,16 @@ bool latlng_extractor::extract_from_value(const std::string &value, S2LatLng &la
     return latlng.is_valid();
 }
 
-dsn::error_s latlng_extractor::set_latlng_indices(std::pair<uint32_t, uint32_t> indices)
+dsn::error_s latlng_extractor::set_latlng_indices(uint32_t latitude_index, uint32_t longitude_index)
 {
-    if (indices.first == indices.second) {
+    if (latitude_index == longitude_index) {
         return dsn::error_s::make(dsn::ERR_INVALID_PARAMETERS,
-                                  "latitude index longitude index should not be equal");
-    } else if (indices.first < indices.second) {
-        _sorted_indices = {(int)indices.first, (int)indices.second};
+                                  "latitude_index and longitude_index should not be equal");
+    } else if (latitude_index < longitude_index) {
+        _sorted_indices = {(int)latitude_index, (int)longitude_index};
         _latlng_reversed = false;
     } else {
-        _sorted_indices = {(int)indices.second, (int)indices.first};
+        _sorted_indices = {(int)longitude_index, (int)latitude_index};
         _latlng_reversed = true;
     }
     return dsn::error_s::ok();

--- a/src/geo/lib/latlng_extractor.h
+++ b/src/geo/lib/latlng_extractor.h
@@ -9,36 +9,29 @@
 #include <s2/s2latlng.h>
 #include <dsn/utility/strings.h>
 
+namespace dsn {
+class error_s;
+} // namespace dsn
+
 namespace pegasus {
 namespace geo {
 
 class latlng_extractor
 {
 public:
-    virtual ~latlng_extractor() = default;
-    virtual const char *name() const = 0;
-    virtual const char *value_sample() const = 0;
-    virtual bool extract_from_value(const std::string &value, S2LatLng &latlng) const = 0;
+    // Extract latitude and longitude from value.
+    bool extract_from_value(const std::string &value, S2LatLng &latlng);
 
-protected:
-    static bool
-    extract_from_value(const std::string &value, std::pair<int, int> indexes, S2LatLng &latlng);
-};
+    // Set latitude and longitude indices in string type value, indices are the ones
+    // when the string type value split into list by '|'.
+    // indices: <latitude index, longitude index>
+    dsn::error_s set_latlng_indices(std::pair<uint32_t, uint32_t> indices);
 
-class latlng_extractor_for_lbs : public latlng_extractor
-{
-public:
-    const char *name() const final;
-    const char *value_sample() const final;
-    bool extract_from_value(const std::string &value, S2LatLng &latlng) const final;
-};
-
-class latlng_extractor_for_aibox : public latlng_extractor
-{
-public:
-    const char *name() const final;
-    const char *value_sample() const final;
-    bool extract_from_value(const std::string &value, S2LatLng &latlng) const final;
+private:
+    // <latitude index, longitude index>
+    std::vector<int> _sorted_indices;
+    // Whether latitude and longitude indices are reversed in '_sorted_indices'.
+    bool _latlng_reversed = false;
 };
 
 } // namespace geo

--- a/src/geo/lib/latlng_extractor.h
+++ b/src/geo/lib/latlng_extractor.h
@@ -28,9 +28,9 @@ public:
     dsn::error_s set_latlng_indices(uint32_t latitude_index, uint32_t longitude_index);
 
 private:
-    // <latitude index, longitude index>
+    // Latitude index and longitude index in sorted order.
     std::vector<int> _sorted_indices;
-    // Whether latitude and longitude indices are reversed in '_sorted_indices'.
+    // Whether '_sorted_indices' is in latitude-longitude order.
     bool _latlng_reversed = false;
 };
 

--- a/src/geo/lib/latlng_extractor.h
+++ b/src/geo/lib/latlng_extractor.h
@@ -19,9 +19,21 @@ public:
     virtual const char *name() const = 0;
     virtual const char *value_sample() const = 0;
     virtual bool extract_from_value(const std::string &value, S2LatLng &latlng) const = 0;
+
+protected:
+    static bool
+    extract_from_value(const std::string &value, std::pair<int, int> indexes, S2LatLng &latlng);
 };
 
 class latlng_extractor_for_lbs : public latlng_extractor
+{
+public:
+    const char *name() const final;
+    const char *value_sample() const final;
+    bool extract_from_value(const std::string &value, S2LatLng &latlng) const final;
+};
+
+class latlng_extractor_for_aibox : public latlng_extractor
 {
 public:
     const char *name() const final;

--- a/src/geo/lib/latlng_extractor.h
+++ b/src/geo/lib/latlng_extractor.h
@@ -25,8 +25,7 @@ public:
 
     // Set latitude and longitude indices in string type value, indices are the ones
     // when the string type value split into list by '|'.
-    // indices: <latitude index, longitude index>
-    dsn::error_s set_latlng_indices(std::pair<uint32_t, uint32_t> indices);
+    dsn::error_s set_latlng_indices(uint32_t latitude_index, uint32_t longitude_index);
 
 private:
     // <latitude index, longitude index>

--- a/src/geo/lib/latlng_extractor.h
+++ b/src/geo/lib/latlng_extractor.h
@@ -20,6 +20,7 @@ class latlng_extractor
 {
 public:
     // Extract latitude and longitude from value.
+    // Return true when succeed.
     bool extract_from_value(const std::string &value, S2LatLng &latlng);
 
     // Set latitude and longitude indices in string type value, indices are the ones

--- a/src/geo/test/config.ini
+++ b/src/geo/test/config.ini
@@ -61,6 +61,5 @@ rpc_call_header_format = NET_HDR_DSN
 rpc_call_channel = RPC_CHANNEL_TCP
 rpc_timeout_milliseconds = 5000
 
-[uri-resolver.dsn://onebox]
-factory = partition_resolver_simple
-arguments = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
+[pegasus.clusters]
+onebox = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603

--- a/src/geo/test/extractor_test.cpp
+++ b/src/geo/test/extractor_test.cpp
@@ -13,15 +13,15 @@ namespace geo {
 TEST(latlng_extractor_test, set_latlng_indices)
 {
     latlng_extractor extractor;
-    ASSERT_FALSE(extractor.set_latlng_indices(std::make_pair(3, 3)).is_ok());
-    ASSERT_TRUE(extractor.set_latlng_indices(std::make_pair(3, 4)).is_ok());
-    ASSERT_TRUE(extractor.set_latlng_indices(std::make_pair(4, 3)).is_ok());
+    ASSERT_FALSE(extractor.set_latlng_indices(3, 3).is_ok());
+    ASSERT_TRUE(extractor.set_latlng_indices(3, 4).is_ok());
+    ASSERT_TRUE(extractor.set_latlng_indices(4, 3).is_ok());
 }
 
 TEST(latlng_extractor_for_lbs_test, extract_from_value)
 {
     latlng_extractor extractor;
-    ASSERT_TRUE(extractor.set_latlng_indices(std::make_pair(5, 4)).is_ok());
+    ASSERT_TRUE(extractor.set_latlng_indices(5, 4).is_ok());
 
     double lat_degrees = 12.345;
     double lng_degrees = 67.890;
@@ -74,7 +74,7 @@ TEST(latlng_extractor_for_lbs_test, extract_from_value)
 TEST(latlng_extractor_for_aibox_test, extract_from_value)
 {
     latlng_extractor extractor;
-    ASSERT_TRUE(extractor.set_latlng_indices(std::make_pair(0, 1)).is_ok());
+    ASSERT_TRUE(extractor.set_latlng_indices(0, 1).is_ok());
 
     double lat_degrees = 12.345;
     double lng_degrees = 67.890;

--- a/src/geo/test/extractor_test.cpp
+++ b/src/geo/test/extractor_test.cpp
@@ -64,5 +64,44 @@ TEST(latlng_extractor_for_lbs_test, extract_from_value)
     ASSERT_FALSE(lbs_extractor->extract_from_value(test_value, latlng));
 }
 
+static std::shared_ptr<latlng_extractor_for_aibox> aibox_extractor =
+    std::make_shared<latlng_extractor_for_aibox>();
+TEST(latlng_extractor_for_aibox_test, extract_from_value)
+{
+    ASSERT_EQ(std::string(aibox_extractor->name()), "latlng_extractor_for_aibox");
+
+    S2LatLng latlng;
+    ASSERT_TRUE(aibox_extractor->extract_from_value(aibox_extractor->value_sample(), latlng));
+
+    double lat_degrees = 12.345;
+    double lng_degrees = 67.890;
+    std::string test_value = std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees);
+    ASSERT_TRUE(aibox_extractor->extract_from_value(test_value, latlng));
+    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
+    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+
+    test_value = std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees) + "|24.043028";
+    ASSERT_TRUE(aibox_extractor->extract_from_value(test_value, latlng));
+    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
+    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+
+    test_value = std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees) + "||";
+    ASSERT_TRUE(aibox_extractor->extract_from_value(test_value, latlng));
+    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
+    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+
+    test_value = "|" + std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees);
+    ASSERT_FALSE(aibox_extractor->extract_from_value(test_value, latlng));
+
+    test_value = "|" + std::to_string(lat_degrees);
+    ASSERT_FALSE(aibox_extractor->extract_from_value(test_value, latlng));
+
+    test_value = std::to_string(lng_degrees) + "|";
+    ASSERT_FALSE(aibox_extractor->extract_from_value(test_value, latlng));
+
+    test_value = "|";
+    ASSERT_FALSE(aibox_extractor->extract_from_value(test_value, latlng));
+}
+
 } // namespace geo
 } // namespace pegasus

--- a/src/geo/test/extractor_test.cpp
+++ b/src/geo/test/extractor_test.cpp
@@ -5,102 +5,107 @@
 #include <memory>
 #include <gtest/gtest.h>
 #include <geo/lib/latlng_extractor.h>
+#include <dsn/utility/errors.h>
 
 namespace pegasus {
 namespace geo {
 
-static std::shared_ptr<latlng_extractor_for_lbs> lbs_extractor =
-    std::make_shared<latlng_extractor_for_lbs>();
+TEST(latlng_extractor_test, set_latlng_indices)
+{
+    latlng_extractor extractor;
+    ASSERT_FALSE(extractor.set_latlng_indices(std::make_pair(3, 3)).is_ok());
+    ASSERT_TRUE(extractor.set_latlng_indices(std::make_pair(3, 4)).is_ok());
+    ASSERT_TRUE(extractor.set_latlng_indices(std::make_pair(4, 3)).is_ok());
+}
+
 TEST(latlng_extractor_for_lbs_test, extract_from_value)
 {
-    ASSERT_EQ(std::string(lbs_extractor->name()), "latlng_extractor_for_lbs");
-
-    S2LatLng latlng;
-    ASSERT_TRUE(lbs_extractor->extract_from_value(lbs_extractor->value_sample(), latlng));
+    latlng_extractor extractor;
+    ASSERT_TRUE(extractor.set_latlng_indices(std::make_pair(5, 4)).is_ok());
 
     double lat_degrees = 12.345;
     double lng_degrees = 67.890;
+    S2LatLng latlng;
+
     std::string test_value = "00:00:00:00:01:5e|2018-04-26|2018-04-28|ezp8xchrr|" +
                              std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees) +
                              "|24.043028|4.15921|0|-1";
-    ASSERT_TRUE(lbs_extractor->extract_from_value(test_value, latlng));
-    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
-    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+    ASSERT_TRUE(extractor.extract_from_value(test_value, latlng));
+    EXPECT_DOUBLE_EQ(latlng.lat().degrees(), lat_degrees);
+    EXPECT_DOUBLE_EQ(latlng.lng().degrees(), lng_degrees);
 
     test_value = "|2018-04-26|2018-04-28|ezp8xchrr|" + std::to_string(lng_degrees) + "|" +
                  std::to_string(lat_degrees) + "|24.043028|4.15921|0|-1";
-    ASSERT_TRUE(lbs_extractor->extract_from_value(test_value, latlng));
-    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
-    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+    ASSERT_TRUE(extractor.extract_from_value(test_value, latlng));
+    EXPECT_DOUBLE_EQ(latlng.lat().degrees(), lat_degrees);
+    EXPECT_DOUBLE_EQ(latlng.lng().degrees(), lng_degrees);
 
     test_value = "00:00:00:00:01:5e||2018-04-28|ezp8xchrr|" + std::to_string(lng_degrees) + "|" +
                  std::to_string(lat_degrees) + "|24.043028|4.15921|0|-1";
-    ASSERT_TRUE(lbs_extractor->extract_from_value(test_value, latlng));
-    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
-    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+    ASSERT_TRUE(extractor.extract_from_value(test_value, latlng));
+    EXPECT_DOUBLE_EQ(latlng.lat().degrees(), lat_degrees);
+    EXPECT_DOUBLE_EQ(latlng.lng().degrees(), lng_degrees);
 
     test_value = "00:00:00:00:01:5e|2018-04-26|2018-04-28|ezp8xchrr|" +
                  std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees) + "||4.15921|0|-1";
-    ASSERT_TRUE(lbs_extractor->extract_from_value(test_value, latlng));
-    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
-    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+    ASSERT_TRUE(extractor.extract_from_value(test_value, latlng));
+    EXPECT_DOUBLE_EQ(latlng.lat().degrees(), lat_degrees);
+    EXPECT_DOUBLE_EQ(latlng.lng().degrees(), lng_degrees);
 
     test_value = "00:00:00:00:01:5e|2018-04-26|2018-04-28|ezp8xchrr|" +
                  std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees) +
                  "|24.043028|4.15921|0|";
-    ASSERT_TRUE(lbs_extractor->extract_from_value(test_value, latlng));
-    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
-    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+    ASSERT_TRUE(extractor.extract_from_value(test_value, latlng));
+    EXPECT_DOUBLE_EQ(latlng.lat().degrees(), lat_degrees);
+    EXPECT_DOUBLE_EQ(latlng.lng().degrees(), lng_degrees);
 
     test_value = "00:00:00:00:01:5e|2018-04-26|2018-04-28|ezp8xchrr||" +
                  std::to_string(lat_degrees) + "|24.043028|4.15921|0|-1";
-    ASSERT_FALSE(lbs_extractor->extract_from_value(test_value, latlng));
+    ASSERT_FALSE(extractor.extract_from_value(test_value, latlng));
 
     test_value = "00:00:00:00:01:5e|2018-04-26|2018-04-28|ezp8xchrr|" +
                  std::to_string(lng_degrees) + "||24.043028|4.15921|0|-1";
-    ASSERT_FALSE(lbs_extractor->extract_from_value(test_value, latlng));
+    ASSERT_FALSE(extractor.extract_from_value(test_value, latlng));
 
     test_value = "00:00:00:00:01:5e|2018-04-26|2018-04-28|ezp8xchrr|||24.043028|4.15921|0|-1";
-    ASSERT_FALSE(lbs_extractor->extract_from_value(test_value, latlng));
+    ASSERT_FALSE(extractor.extract_from_value(test_value, latlng));
 }
 
-static std::shared_ptr<latlng_extractor_for_aibox> aibox_extractor =
-    std::make_shared<latlng_extractor_for_aibox>();
 TEST(latlng_extractor_for_aibox_test, extract_from_value)
 {
-    ASSERT_EQ(std::string(aibox_extractor->name()), "latlng_extractor_for_aibox");
-
-    S2LatLng latlng;
-    ASSERT_TRUE(aibox_extractor->extract_from_value(aibox_extractor->value_sample(), latlng));
+    latlng_extractor extractor;
+    ASSERT_TRUE(extractor.set_latlng_indices(std::make_pair(0, 1)).is_ok());
 
     double lat_degrees = 12.345;
     double lng_degrees = 67.890;
-    std::string test_value = std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees);
-    ASSERT_TRUE(aibox_extractor->extract_from_value(test_value, latlng));
-    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
-    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+    S2LatLng latlng;
 
-    test_value = std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees) + "|24.043028";
-    ASSERT_TRUE(aibox_extractor->extract_from_value(test_value, latlng));
-    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
-    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+    std::string test_value = std::to_string(lat_degrees) + "|" + std::to_string(lng_degrees);
+    ASSERT_TRUE(extractor.extract_from_value(test_value, latlng));
+    EXPECT_DOUBLE_EQ(latlng.lat().degrees(), lat_degrees);
+    EXPECT_DOUBLE_EQ(latlng.lng().degrees(), lng_degrees);
 
-    test_value = std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees) + "||";
-    ASSERT_TRUE(aibox_extractor->extract_from_value(test_value, latlng));
-    ASSERT_LE(std::abs(latlng.lat().degrees() - lat_degrees), 0.000001);
-    ASSERT_LE(std::abs(latlng.lng().degrees() - lng_degrees), 0.000001);
+    test_value = std::to_string(lat_degrees) + "|" + std::to_string(lng_degrees) + "|24.043028";
+    ASSERT_TRUE(extractor.extract_from_value(test_value, latlng));
+    EXPECT_DOUBLE_EQ(latlng.lat().degrees(), lat_degrees);
+    EXPECT_DOUBLE_EQ(latlng.lng().degrees(), lng_degrees);
 
-    test_value = "|" + std::to_string(lng_degrees) + "|" + std::to_string(lat_degrees);
-    ASSERT_FALSE(aibox_extractor->extract_from_value(test_value, latlng));
+    test_value = std::to_string(lat_degrees) + "|" + std::to_string(lng_degrees) + "||";
+    ASSERT_TRUE(extractor.extract_from_value(test_value, latlng));
+    EXPECT_DOUBLE_EQ(latlng.lat().degrees(), lat_degrees);
+    EXPECT_DOUBLE_EQ(latlng.lng().degrees(), lng_degrees);
+
+    test_value = "|" + std::to_string(lat_degrees) + "|" + std::to_string(lng_degrees);
+    ASSERT_FALSE(extractor.extract_from_value(test_value, latlng));
 
     test_value = "|" + std::to_string(lat_degrees);
-    ASSERT_FALSE(aibox_extractor->extract_from_value(test_value, latlng));
+    ASSERT_FALSE(extractor.extract_from_value(test_value, latlng));
 
     test_value = std::to_string(lng_degrees) + "|";
-    ASSERT_FALSE(aibox_extractor->extract_from_value(test_value, latlng));
+    ASSERT_FALSE(extractor.extract_from_value(test_value, latlng));
 
     test_value = "|";
-    ASSERT_FALSE(aibox_extractor->extract_from_value(test_value, latlng));
+    ASSERT_FALSE(extractor.extract_from_value(test_value, latlng));
 }
 
 } // namespace geo

--- a/src/geo/test/geo_test.cpp
+++ b/src/geo/test/geo_test.cpp
@@ -20,8 +20,7 @@ class geo_client_test : public ::testing::Test
 public:
     geo_client_test()
     {
-        _geo_client.reset(new pegasus::geo::geo_client(
-            "config.ini", "onebox", "temp", "temp_geo", new latlng_extractor_for_lbs()));
+        _geo_client.reset(new pegasus::geo::geo_client("config.ini", "onebox", "temp", "temp_geo"));
     }
 
     pegasus_client *common_data_client() { return _geo_client->_common_data_client; }

--- a/src/redis_protocol/proxy/config.ini
+++ b/src/redis_protocol/proxy/config.ini
@@ -8,7 +8,7 @@ count = 1
 [apps.proxy]
 name = proxy
 type = proxy
-arguments = redis_cluster temp
+arguments = onebox temp
 ports = 6379
 pools = THREAD_POOL_DEFAULT
 run = true
@@ -123,7 +123,6 @@ falcon_host = 127.0.0.1
 falcon_port = 1988
 falcon_path = /v1/push
 
-[uri-resolver.dsn://redis_cluster]
-factory = partition_resolver_simple
-arguments = localhost:34601
+[pegasus.clusters]
+onebox = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603
 

--- a/src/redis_protocol/proxy_lib/redis_parser.cpp
+++ b/src/redis_protocol/proxy_lib/redis_parser.cpp
@@ -66,11 +66,8 @@ redis_parser::redis_parser(proxy_stub *op, dsn::message_ex *first_msg)
             meta_list, PEGASUS_CLUSTER_SECTION_NAME.c_str(), op->get_cluster());
         r = new ::dsn::apps::rrdb_client(op->get_cluster(), meta_list, op->get_app());
         if (strlen(op->get_geo_app()) != 0) {
-            _geo_client = dsn::make_unique<geo::geo_client>("config.ini",
-                                                            op->get_cluster(),
-                                                            op->get_app(),
-                                                            op->get_geo_app(),
-                                                            new geo::latlng_extractor_for_lbs());
+            _geo_client = dsn::make_unique<geo::geo_client>(
+                "config.ini", op->get_cluster(), op->get_app(), op->get_geo_app());
         }
     } else {
         r = new ::dsn::apps::rrdb_client();

--- a/src/redis_protocol/proxy_ut/config.ini
+++ b/src/redis_protocol/proxy_ut/config.ini
@@ -8,7 +8,7 @@ count = 1
 [apps.proxy]
 name = proxy
 type = proxy
-arguments = redis_cluster temp
+arguments = onebox temp
 ports = 12345
 pools = THREAD_POOL_DEFAULT
 run = true
@@ -92,7 +92,5 @@ allow_inline = false
 is_trace = false
 allow_inline = false
 
-[uri-resolver.dsn://redis_cluster]
-factory = partition_resolver_simple
-arguments = localhost:34601, localhost:34602, localhost:34603
-
+[pegasus.clusters]
+onebox = 127.0.0.1:34601,127.0.0.1:34602,127.0.0.1:34603

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -1709,12 +1709,10 @@ bool copy_data(command_executor *e, shell_context *sc, arguments args)
 
     std::unique_ptr<pegasus::geo::geo_client> target_geo_client;
     if (is_geo_data) {
-        target_geo_client.reset(
-            new pegasus::geo::geo_client("config.ini",
-                                         target_cluster_name.c_str(),
-                                         target_app_name.c_str(),
-                                         target_geo_app_name.c_str(),
-                                         new pegasus::geo::latlng_extractor_for_lbs()));
+        target_geo_client.reset(new pegasus::geo::geo_client("config.ini",
+                                                             target_cluster_name.c_str(),
+                                                             target_app_name.c_str(),
+                                                             target_geo_app_name.c_str()));
     }
 
     std::vector<pegasus::pegasus_client::pegasus_scanner *> raw_scanners;


### PR DESCRIPTION
### What problem does this PR solve? 
Support more configuration for geo_client.

### What is changed and how it works?
set `min_level`, `latitude_index` and `longitude_index` in geo_client's config.ini before inserting data into DB, and they are immutable after data has been inserted.
```
[geo_client.lib]
...
min_level = 12
max_level = 16
latitude_index = 5
longitude_index = 4
```

`min_level` and `max_level` are parameters for data search algorithm in S2.
https://github.com/XiaoMi/pegasus/blob/d227b4c0b6f555572025f433de85ff6eca7abb86/src/geo/lib/geo_client.cpp#L463 https://github.com/XiaoMi/pegasus/blob/d227b4c0b6f555572025f433de85ff6eca7abb86/src/geo/lib/geo_client.cpp#L510
`latitude_index` and `longitude_index` are parameters for extracting latitude and longitude from string type value. 
https://github.com/XiaoMi/pegasus/blob/b7e9b2ecb292cbacfca4b08113190084155f0202/src/geo/lib/latlng_extractor.cpp#L62
### Check List

#### Tests

- Unit test
- Manual test (add detailed scripts or steps below)

#### Code changes

#### Side effects

#### Related changes

- Need to cherry-pick to the release branch
- Need to be included in the release note
