### PR TITLE
GEO: support GEOPOS API for redis proxy

### DIFF
--- a/src/redis_protocol/proxy_lib/redis_parser.h
+++ b/src/redis_protocol/proxy_lib/redis_parser.h
@@ -52,24 +52,29 @@ protected:
     };
     struct redis_bulk_string : public redis_base_type
     {
-        int length = 0;
+        int length = -1;
         ::dsn::blob data;
 
+        redis_bulk_string() = default;
         redis_bulk_string(const std::string &str)
             : length((int)str.length()), data(str.data(), 0, (unsigned int)str.length())
         {
         }
-        redis_bulk_string(int len = 0, const char *str = nullptr) : length(len), data(str, 0, len)
-        {
-        }
+        redis_bulk_string(int len, const char *str) : length(len), data(str, 0, len) {}
         explicit redis_bulk_string(const ::dsn::blob &bb) : length(bb.length()), data(bb) {}
 
         void marshalling(::dsn::binary_writer &write_stream) const final;
     };
     struct redis_array : public redis_base_type
     {
-        int count = 0;
-        std::list<std::shared_ptr<redis_base_type>> array;
+        int count = -1;
+        std::vector<std::shared_ptr<redis_base_type>> array;
+
+        void resize(size_t size)
+        {
+            count = size;
+            array.resize(size);
+        }
 
         void marshalling(::dsn::binary_writer &write_stream) const final;
     };
@@ -146,6 +151,7 @@ protected:
     DECLARE_REDIS_HANDLER(setex)
     DECLARE_REDIS_HANDLER(ttl)
     DECLARE_REDIS_HANDLER(geo_dist)
+    DECLARE_REDIS_HANDLER(geo_pos)
     DECLARE_REDIS_HANDLER(geo_radius)
     DECLARE_REDIS_HANDLER(geo_radius_by_member)
     DECLARE_REDIS_HANDLER(incr)
@@ -197,6 +203,8 @@ protected:
         entry.response.store(resp, std::memory_order_release);
         reply_all_ready();
     }
+
+    std::shared_ptr<redis_bulk_string> construct_bulk_string(double data);
 
     typedef void (*redis_call_handler)(redis_parser *, message_entry &);
     static std::unordered_map<std::string, redis_call_handler> s_dispatcher;

--- a/src/redis_protocol/proxy_ut/redis_proxy_test.cpp
+++ b/src/redis_protocol/proxy_ut/redis_proxy_test.cpp
@@ -140,6 +140,20 @@ public:
             ASSERT_TRUE(got_a_message);
         }
 
+        // geo GEOPOS command
+        {
+            got_a_message = false;
+            entry_index = 0;
+            rr.length = 5;
+            rr.buffers = {{6, "GEOPOS"}, {0, ""}, {7, "member1"}, {7, "member2"}, {7, "member3"}};
+
+            const char *request_data = "*5\r\n$6\r\nGEOPOS\r\n$0\r\n\r\n$"
+                                       "7\r\nmember1\r\n$7\r\nmember2\r\n$7\r\nmember3\r\n";
+            auto request = create_message(request_data);
+            ASSERT_TRUE(parse(request));
+            ASSERT_TRUE(got_a_message);
+        }
+
         // wrong message
         {
             got_a_message = false;
@@ -200,8 +214,7 @@ public:
             redis_request &ra = reserved_entry[entry_index]->request;
             ra.length = dsn::rand::next_u32(1, 20);
             ra.buffers.resize(ra.length);
-            for (unsigned int i = 0; i != ra.length; ++i) {
-                redis_bulk_string &bs = ra.buffers[i];
+            for (auto &bs : ra.buffers) {
                 bs.length = dsn::rand::next_u32(0, 8);
                 if (bs.length == 0) {
                     bs.length = -1;

--- a/src/redis_protocol/proxy_ut/redis_proxy_test.cpp
+++ b/src/redis_protocol/proxy_ut/redis_proxy_test.cpp
@@ -87,7 +87,7 @@ public:
         // simple case
         {
             rr.length = 3;
-            rr.buffers = {{3, "SET"}, {3, "foo"}, {3, "bar"}};
+            rr.buffers = {{"SET"}, {"foo"}, {"bar"}};
             got_a_message = false;
             entry_index = 0;
 
@@ -116,7 +116,7 @@ public:
             entry_index = 0;
             rr.length = 6;
             rr.buffers = {
-                {9, "GEORADIUS"}, {0, ""}, {5, "123.4"}, {5, "56.78"}, {3, "100"}, {1, "m"}};
+                {"GEORADIUS"}, {""}, {"123.4"}, {"56.78"}, {"100"}, {"m"}};
 
             const char *request_data = "*6\r\n$9\r\nGEORADIUS\r\n$0\r\n\r\n$5\r\n123.4\r\n$5\r\n56."
                                        "78\r\n$3\r\n100\r\n$1\r\nm\r\n";
@@ -131,7 +131,7 @@ public:
             entry_index = 0;
             rr.length = 5;
             rr.buffers = {
-                {17, "GEORADIUSBYMEMBER"}, {0, ""}, {7, "member1"}, {6, "1000.5"}, {2, "km"}};
+                {"GEORADIUSBYMEMBER"}, {""}, {"member1"}, {"1000.5"}, {"km"}};
 
             const char *request_data = "*5\r\n$17\r\nGEORADIUSBYMEMBER\r\n$0\r\n\r\n$"
                                        "7\r\nmember1\r\n$6\r\n1000.5\r\n$2\r\nkm\r\n";
@@ -145,7 +145,7 @@ public:
             got_a_message = false;
             entry_index = 0;
             rr.length = 5;
-            rr.buffers = {{6, "GEOPOS"}, {0, ""}, {7, "member1"}, {7, "member2"}, {7, "member3"}};
+            rr.buffers = {{"GEOPOS"}, {""}, {"member1"}, {"member2"}, {"member3"}};
 
             const char *request_data = "*5\r\n$6\r\nGEOPOS\r\n$0\r\n\r\n$"
                                        "7\r\nmember1\r\n$7\r\nmember2\r\n$7\r\nmember3\r\n";
@@ -180,7 +180,7 @@ public:
             got_a_message = false;
             entry_index = 0;
             rr.length = 3;
-            rr.buffers = {{3, "set"}, {5, "hello"}, {0, ""}};
+            rr.buffers = {{"set"}, {"hello"}, {""}};
 
             const char *data = "*3\r\n$3\r\nset\r\n$5\r\nhello\r\n$0\r\n\r\n";
             auto request = create_message(data);
@@ -193,7 +193,7 @@ public:
             got_a_message = false;
             entry_index = 0;
             rr.length = 1;
-            rr.buffers = {{-1, ""}};
+            rr.buffers = {{redis_bulk_string()}};
 
             const char *data = "*1\r\n$-1\r\n";
             ASSERT_TRUE(parse(create_message(data)));


### PR DESCRIPTION
### What problem does this PR solve?
Support GEOPOS API for geo_client and redis proxy

### What is changed and how it works?
Add new client API

### Check List

#### Tests

- Unit test
- Manual test (add detailed scripts or steps below)
1. start geo redis proxy
2. excute commands as follows:
```
127.0.0.1:6379> set key1 11|111
OK
127.0.0.1:6379> set key2 22|122
OK
127.0.0.1:6379> geopos "" not_exist1 key1 not_exist2 key2 not_exist3
1) (nil)
2) 1) "111.000000"
   2) "11.000000"
3) (nil)
4) 1) "122.000000"
   2) "22.000000"
5) (nil)
```

#### Code changes

- Has exported function/method change
Yes
- Has exported variable/fields change
Not relate
- Has interface methods change
Yes
- Has persistent data change
Not relate

#### Side effects

- Possible performance regression
No
- Increased code complexity
A little
- Breaking backward compatibility
No

#### Related changes

- Need to cherry-pick to the release branch
Yes
- Need to update the documentation
Yes
- Need to be included in the release note
Yes