### PR TITLE
CMake: fix client_lib

### DIFF
--- a/src/client_lib/CMakeLists.txt
+++ b/src/client_lib/CMakeLists.txt
@@ -5,7 +5,7 @@ file("GLOB"
 add_definitions(-fPIC)
 
 add_library(pegasus_client_impl_objects OBJECT ${source_files})
-target_link_libraries(pegasus_client_impl_objects pegasus_base)
+target_include_directories(pegasus_client_impl_objects PUBLIC $<TARGET_PROPERTY:RocksDB::rocksdb,INTERFACE_INCLUDE_DIRECTORIES>)
 
 # both shared & static version of pegasus client depends on boost_system,boost_filesystem,aio,dl
 #


### PR DESCRIPTION
## What problem does this PR solve? <!--add issue link with summary if exists-->

On CMake <3.12, OBJECT libraries shouldn't link to anything. 
On CMake >=3.12, OBJECT libraries can use target_link_libraries().
As the minimun version of CMake is 3.5.2, we should not use target_link_libraries on OBJECT libraries.

### What is changed and how it works?

use target_include_directories to include headers of rocksdb in client_lib

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- No code

Related changes

- Need to cherry-pick to the release branch
