### PR TITLE
compile/link: fix dependency error of curl

### DIFF
--- a/src/redis_protocol/proxy/CMakeLists.txt
+++ b/src/redis_protocol/proxy/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MY_PROJ_LIBS pegasus.rproxylib
                  prometheus-cpp-push
                  prometheus-cpp-core
                  curl
+                 idn
                  event
                  s2
                  pegasus_client_static

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -27,6 +27,7 @@ set(MY_PROJ_LIBS
     prometheus-cpp-push
     prometheus-cpp-core
     curl
+    idn
     pegasus_client_static
     zookeeper_mt
     event


### PR DESCRIPTION
### What problem does this PR solve?
fix dependency error of curl when compile project by gcc 7.4.0
link error looks like:
```
/home/laiyingchun/pegasus/rdsn/thirdparty/output/lib/libcurl.a(libcurl_la-url.o): In function `fix_hostname':
url.c:(.text+0xc28): undefined reference to `stringprep_check_version'
url.c:(.text+0xc46): undefined reference to `idna_to_ascii_lz'
url.c:(.text+0xc4d): undefined reference to `stringprep_locale_charset'
url.c:(.text+0xc7f): undefined reference to `idna_to_unicode_lzlz'
url.c:(.text+0xcda): undefined reference to `tld_check_lz'
url.c:(.text+0xcef): undefined reference to `idn_free'
url.c:(.text+0xcf8): undefined reference to `tld_strerror'
/home/laiyingchun/pegasus/rdsn/thirdparty/output/lib/libcurl.a(libcurl_la-url.o): In function `Curl_disconnect':
url.c:(.text+0x5c2a): undefined reference to `idn_free'
url.c:(.text+0x5c46): undefined reference to `idn_free'
/home/laiyingchun/pegasus/rdsn/thirdparty/output/lib/libcurl.a(libcurl_la-url.o): In function `Curl_connect':
url.c:(.text+0x89b6): undefined reference to `idn_free'
url.c:(.text+0x8af2): undefined reference to `idn_free'
/home/laiyingchun/pegasus/rdsn/thirdparty/output/lib/libcurl.a(libcurl_la-strerror.o): In function `Curl_idn_strerror':
strerror.c:(.text+0x773): undefined reference to `idna_strerror'
collect2: error: ld returned 1 exit status
make[2]: *** [redis_protocol/proxy/pegasus_rproxy] Error 1
make[1]: *** [redis_protocol/proxy/CMakeFiles/pegasus_rproxy.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

### What is changed and how it works?
CMakeLists.txt

### Check List

#### Tests

- Unit test
yes
- Integration test
yes
- Manual test (add detailed scripts or steps below)
no
- No code
yes

#### Code changes

- Has exported function/method change
no
- Has exported variable/fields change
no
- Has interface methods change
no
- Has persistent data change
no

#### Side effects

- Possible performance regression
no
- Increased code complexity
no
- Breaking backward compatibility
no

#### Related changes

- Need to cherry-pick to the release branch
yes
- Need to update the documentation
no
- Need to be included in the release note
no