### PR TITLE
fix: unit tests & travis.sh exit with err

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -17,7 +17,9 @@ if [ "$modified" ]; then
 fi
 
 "${root}"/run.sh build -c --skip_thirdparty --disable_gperf && ./run.sh test
-
-if [ $? ]; then
-    echo "travis failed with exit code $?"
+ret=$?
+if [ $ret ]; then
+    echo "travis failed with exit code $ret"
 fi
+
+exit $ret

--- a/src/base/test/main.cpp
+++ b/src/base/test/main.cpp
@@ -8,6 +8,6 @@
 GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
-    int ans = RUN_ALL_TESTS();
-    dsn_exit(ans);
+    int ret = RUN_ALL_TESTS();
+    dsn_exit(ret);
 }

--- a/src/geo/test/main.cpp
+++ b/src/geo/test/main.cpp
@@ -8,6 +8,6 @@
 GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
-    int ans = RUN_ALL_TESTS();
-    dsn_exit(ans);
+    int ret = RUN_ALL_TESTS();
+    dsn_exit(ret);
 }

--- a/src/redis_protocol/proxy_ut/redis_proxy_test.cpp
+++ b/src/redis_protocol/proxy_ut/redis_proxy_test.cpp
@@ -602,6 +602,6 @@ GTEST_API_ int main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
     dsn_init();
-    int ans = RUN_ALL_TESTS();
-    dsn_exit(ans);
+    int ret = RUN_ALL_TESTS();
+    dsn_exit(ret);
 }

--- a/src/server/test/main.cpp
+++ b/src/server/test/main.cpp
@@ -8,6 +8,7 @@
 #include "server/pegasus_server_impl.h"
 
 std::atomic_bool gtest_done{false};
+std::atomic_int gtest_ret{false};
 
 class gtest_app : public dsn::service_app
 {
@@ -17,7 +18,7 @@ public:
     dsn::error_code start(const std::vector<std::string> &args) override
     {
         dsn::service_app::start(args);
-        RUN_ALL_TESTS();
+        gtest_ret = RUN_ALL_TESTS();
         gtest_done = true;
         return dsn::ERR_OK;
     }
@@ -37,6 +38,5 @@ GTEST_API_ int main(int argc, char **argv)
     while (!gtest_done) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
-
-    dsn_exit(0);
+    dsn_exit(gtest_ret);
 }

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -38,7 +38,7 @@ set(MY_PROJ_LIBS
 
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config.ini")
 
-set(MY_BOOST_LIBS Boost::system Boost::filesystem)
+set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
 
 SET(CMAKE_INSTALL_RPATH ".")
 SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)

--- a/src/test/function_test/main.cpp
+++ b/src/test/function_test/main.cpp
@@ -43,6 +43,6 @@ GTEST_API_ int main(int argc, char **argv)
 
     int gargc = argc - 2;
     testing::InitGoogleTest(&gargc, argv + 2);
-    int ans = RUN_ALL_TESTS();
-    dsn_exit(ans);
+    int ret = RUN_ALL_TESTS();
+    dsn_exit(ret);
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

1. pegasus_unit_test doesn't return err when it failed

1. scripts/travis.sh exit 0 even tests failed

### What is changed and how it works?
fix

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Related changes

- Need to cherry-pick to the release branch
