### PR TITLE
build: pack boost.regex with binaries

### DIFF
--- a/scripts/pack_client.sh
+++ b/scripts/pack_client.sh
@@ -93,6 +93,8 @@ copy_file `get_boost_lib $custom_boost_lib system` ${pack}/lib
 ln -sf `ls ${pack}/lib | grep libboost_system` ${pack}/lib/libboost_system.so
 copy_file `get_boost_lib $custom_boost_lib filesystem` ${pack}/lib
 ln -sf `ls ${pack}/lib | grep libboost_filesystem` ${pack}/lib/libboost_filesystem.so
+copy_file `get_boost_lib $custom_boost_lib regex` ${pack}/lib
+ln -sf `ls ${pack}/lib | grep libboost_regex` ${pack}/lib/libboost_regex.so
 
 cp -v -r ./src/include ${pack}
 

--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -97,6 +97,7 @@ copy_file ./src/server/config.ini ${pack}/bin
 
 copy_file `get_boost_lib $custom_boost_lib system` ${pack}/bin
 copy_file `get_boost_lib $custom_boost_lib filesystem` ${pack}/bin
+copy_file `get_boost_lib $custom_boost_lib regex` ${pack}/bin
 copy_file `get_stdcpp_lib $custom_gcc` ${pack}/bin
 copy_file `get_system_lib server snappy` ${pack}/bin/`get_system_libname server snappy`
 copy_file `get_system_lib server crypto` ${pack}/bin/`get_system_libname server crypto`

--- a/scripts/pack_tools.sh
+++ b/scripts/pack_tools.sh
@@ -103,6 +103,7 @@ copy_file ./rdsn/thirdparty/output/lib/libPoco*.so.48 ${pack}/DSN_ROOT/lib/
 copy_file ./rdsn/thirdparty/output/lib/libtcmalloc_and_profiler.so.4 ${pack}/DSN_ROOT/lib/
 copy_file `get_boost_lib $custom_boost_lib system` ${pack}/DSN_ROOT/lib/
 copy_file `get_boost_lib $custom_boost_lib filesystem` ${pack}/DSN_ROOT/lib/
+copy_file `get_boost_lib $custom_boost_lib regex` ${pack}/DSN_ROOT/lib/
 copy_file `get_stdcpp_lib $custom_gcc` ${pack}/DSN_ROOT/lib/
 copy_file `get_system_lib shell snappy` ${pack}/DSN_ROOT/lib/`get_system_libname shell snappy`
 copy_file `get_system_lib shell crypto` ${pack}/DSN_ROOT/lib/`get_system_libname shell crypto`


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix problem for missing boost regex library.

### What is changed and how it works?

Pack up libboost_regex.so in pack_client.sh, pack_server.sh, pack_tools.sh.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

Related changes

- Need to cherry-pick to the release branch
