### PR TITLE
build(cmake): cleanup lib links

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -536,7 +536,7 @@ function run_start_onebox()
     COLLECTOR_COUNT=0
     APP_NAME=temp
     PARTITION_COUNT=8
-    WAIT_HEALHY=false
+    WAIT_HEALTHY=false
     SERVER_PATH=${DSN_ROOT}/bin/pegasus_server
     CONFIG_FILE=""
     USE_PRODUCT_CONFIG=false
@@ -568,7 +568,7 @@ function run_start_onebox()
                 shift
                 ;;
             -w|--wait_healthy)
-                WAIT_HEALHY=true
+                WAIT_HEALTHY=true
                 ;;
             -s|--server_path)
                 SERVER_PATH="$2"
@@ -680,7 +680,7 @@ function run_start_onebox()
         cd ..
     fi
 
-    if [ $WAIT_HEALHY == "true" ]; then
+    if [ $WAIT_HEALTHY == "true" ]; then
         cd $ROOT
         echo "Wait cluster to become healthy..."
         sleeped=0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,10 @@ message (STATUS "pegasus Installation directory: CMAKE_INSTALL_PREFIX = " ${CMAK
 set(CMAKE_PREFIX_PATH ${PEGASUS_PROJECT_DIR}/rocksdb/build/output;${CMAKE_PREFIX_PATH})
 find_package(RocksDB REQUIRED) # RocksDB::rocksdb means librocksdb.a
 
+#prometheus
+set(CMAKE_PREFIX_PATH ${DSN_THIRDPARTY_ROOT};${CMAKE_PREFIX_PATH})
+find_package(prometheus-cpp)#TODO(huangwei5) make it optional
+
 add_subdirectory(base)
 add_subdirectory(reporter)
 add_subdirectory(base/test)

--- a/src/geo/bench/CMakeLists.txt
+++ b/src/geo/bench/CMakeLists.txt
@@ -15,7 +15,6 @@ set(MY_PROJ_LIBS
         s2testing
         s2
         pegasus_client_static
-        fmt
         RocksDB::rocksdb
         )
 

--- a/src/geo/lib/CMakeLists.txt
+++ b/src/geo/lib/CMakeLists.txt
@@ -13,7 +13,6 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 set(MY_PROJ_LIBS ""
         # s2
         # pegasus_client_static
-        # fmt
         )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem)

--- a/src/geo/test/CMakeLists.txt
+++ b/src/geo/test/CMakeLists.txt
@@ -15,7 +15,6 @@ set(MY_PROJ_LIBS
         s2testing
         s2
         pegasus_client_static
-        fmt
         gtest)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem)

--- a/src/redis_protocol/proxy/CMakeLists.txt
+++ b/src/redis_protocol/proxy/CMakeLists.txt
@@ -12,15 +12,10 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 set(MY_PROJ_LIBS pegasus.rproxylib
                  pegasus_geo_lib
                  pegasus_reporter
-                 prometheus-cpp-pull
-                 prometheus-cpp-push
-                 prometheus-cpp-core
-                 curl
-                 idn
                  event
                  s2
                  pegasus_client_static
-                 fmt)
+                 )
 
 set(MY_BINPLACES "config.ini")
 

--- a/src/redis_protocol/proxy_ut/CMakeLists.txt
+++ b/src/redis_protocol/proxy_ut/CMakeLists.txt
@@ -10,17 +10,15 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_LIBS gtest pthread)
-
 set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 
 set(MY_PROJ_LIBS pegasus.rproxylib
                 pegasus_base
-                ${MY_PROJ_LIBS}
                 pegasus_geo_lib
                 s2
                 pegasus_client_static
-                fmt)
+                gtest
+                )
 
 set(MY_BINPLACES "config.ini" "run.sh")
 

--- a/src/reporter/CMakeLists.txt
+++ b/src/reporter/CMakeLists.txt
@@ -12,4 +12,6 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 dsn_add_static_library()
 
-target_link_libraries(${MY_PROJ_NAME} PUBLIC pegasus_base) # TODO(huangwei5): dsn_add_static_library doesnt link libs, need fix
+target_link_libraries(${MY_PROJ_NAME} PUBLIC pegasus_base
+                                            prometheus-cpp::push
+                                            ) # TODO(huangwei5): dsn_add_static_library doesnt link libs, need fix

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -22,11 +22,6 @@ set(MY_PROJ_LIBS
     RocksDB::rocksdb
     pegasus_reporter
     pegasus_base
-    prometheus-cpp-pull
-    prometheus-cpp-push
-    prometheus-cpp-core
-    curl
-    idn
     pegasus_client_static
     zookeeper_mt
     event
@@ -35,11 +30,6 @@ set(MY_PROJ_LIBS
     PocoFoundation
     PocoNetSSL
     PocoJSON
-    crypto
-    fmt
-    rt
-    aio
-    pthread
     )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -100,10 +100,10 @@
   app_type = pegasus
   partition_count = @PARTITION_COUNT@
 
-; [meta_server.apps.stat]
-;   app_name = stat
-;   app_type = pegasus
-;   partition_count = 4
+[meta_server.apps.stat]
+  app_name = stat
+  app_type = pegasus
+  partition_count = 4
 
 [pegasus.server]
   perf_counter_cluster_name = onebox

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -100,10 +100,10 @@
   app_type = pegasus
   partition_count = @PARTITION_COUNT@
 
-[meta_server.apps.stat]
-  app_name = stat
-  app_type = pegasus
-  partition_count = 4
+; [meta_server.apps.stat]
+;   app_name = stat
+;   app_type = pegasus
+;   partition_count = 4
 
 [pegasus.server]
   perf_counter_cluster_name = onebox

--- a/src/server/test/CMakeLists.txt
+++ b/src/server/test/CMakeLists.txt
@@ -30,15 +30,8 @@ set(MY_PROJ_LIBS
         PocoFoundation
         PocoNetSSL
         PocoJSON
-        crypto
-        fmt
-        prometheus-cpp-push
-        prometheus-cpp-core
-        prometheus-cpp-pull
-        curl
         pegasus_base
         gtest
-        z rt aio pthread
         )
 add_definitions(-DPEGASUS_UNIT_TEST)
 add_definitions(-DENABLE_FAIL)

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -26,14 +26,10 @@ set(MY_PROJ_LIBS
     PocoFoundation
     PocoNetSSL
     PocoJSON
-    crypto
-    fmt
     pegasus_geo_lib
     RocksDB::rocksdb
     s2
-    rt
-    aio
-    pthread)
+    )
 
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config.ini")
 

--- a/src/test/bench_test/CMakeLists.txt
+++ b/src/test/bench_test/CMakeLists.txt
@@ -13,7 +13,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 set(MY_PROJ_LIBS
         pegasus_client_static
         RocksDB::rocksdb
-        fmt)
+        )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem)
 

--- a/src/test/function_test/CMakeLists.txt
+++ b/src/test/function_test/CMakeLists.txt
@@ -14,14 +14,8 @@ set(MY_PROJ_LIBS
     dsn.replication.ddlclient
     dsn_replication_common
     pegasus_client_static
-    fmt
+    gtest
     )
-
-if (UNIX)
-    set(MY_PROJ_LIBS ${MY_PROJ_LIBS} gtest pthread)
-else()
-    set(MY_PROJ_LIBS ${MY_PROJ_LIBS} gtest)
-endif()
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem Boost::regex)
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/XiaoMi/pegasus/issues/361#issuecomment-515656652
1. cleanup prometheus links
1. cleanup default libs
1. disable create table stat in onebox
### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code
