### PR TITLE
build(cmake): fix curl link of prometheus

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,10 +42,6 @@ message (STATUS "pegasus Installation directory: CMAKE_INSTALL_PREFIX = " ${CMAK
 set(CMAKE_PREFIX_PATH ${PEGASUS_PROJECT_DIR}/rocksdb/build/output;${CMAKE_PREFIX_PATH})
 find_package(RocksDB REQUIRED) # RocksDB::rocksdb means librocksdb.a
 
-#prometheus
-set(CMAKE_PREFIX_PATH ${DSN_THIRDPARTY_ROOT};${CMAKE_PREFIX_PATH})
-find_package(prometheus-cpp)#TODO(huangwei5) make it optional
-
 add_subdirectory(base)
 add_subdirectory(reporter)
 add_subdirectory(base/test)

--- a/src/reporter/CMakeLists.txt
+++ b/src/reporter/CMakeLists.txt
@@ -10,6 +10,16 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
+# prometheus
+set(CMAKE_PREFIX_PATH ${DSN_THIRDPARTY_ROOT};${CMAKE_PREFIX_PATH})
+find_package(prometheus-cpp)#TODO(huangwei5): make it optional
+# the INTERFACE_LINK_LIBRARIES of prometheus contains the absolute path of libcurl
+# when we use the compiled prometheus-cpp libs, the path of libcurl should be our own path
+find_package(CURL)
+get_target_property(_libs prometheus-cpp::push INTERFACE_LINK_LIBRARIES)
+string(REGEX REPLACE ";/.*libcurl\.a" ";${CURL_LIBRARIES}" _libs "${_libs}")
+set_target_properties(prometheus-cpp::push PROPERTIES INTERFACE_LINK_LIBRARIES "${_libs}")
+
 dsn_add_static_library()
 
 target_link_libraries(${MY_PROJ_NAME} PUBLIC pegasus_base


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
使用find_package导入prometheus后, 由于prometheus-cpp的export写的不够灵活, INTERFACE_LINK_LIBRARIES中的curl库是绝对地址.
 这就导致travis的build出现问题, 因为travis中thirdparty是prebuild的, 所以curl路径写死了为: `/home/travis/build/XiaoMi/pegasus/rdsn/thirdparty/output/lib/libcurl.a`. 
这样的话, 我们个人的pegasus分支跑travis都会出现找不到`/home/travis/build/XiaoMi/pegasus/rdsn/thirdparty/output/lib/libcurl.a`的问题, 而编译失败.

### What is changed and how it works?
现在提的解决方法是, 通过替换prometheus的INTERFACE_LINK_LIBRARIES为当前工程中能find到的curl库路径.

还有一个工作量大点的方案是, 将prometheus改成optional的, 不指定编译, 就不要编了. 之后也可以考虑将redis/geo等也做成optional. 更进一步地, 下载thirdparty也可以选项化.

**大家看看有没有必要**

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

