### PR TITLE
fix: fix the bug of deadlock in info collector in onebox environment

### DIFF
--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -86,6 +86,12 @@
   name = default
   partitioned = false
   worker_priority = THREAD_xPRIORITY_NORMAL
+  # The worker count in THREAD_POOL_DEFAULT must be >= 5.
+  # Because in info collector server, there are four timer tasks(LPC_PEGASUS_APP_STAT_TIMER, LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
+  # LPC_DETECT_AVAILABLE and LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER). Each of these timer tasks occupies a thread in THREAD_POOL_DEFAULT.
+  # Each of these timer tasks calls remote procedure to meta server(which produce a callback), and waits for the rpc's callback to execute.
+  # If the worker_count <= 4, all of these threads are occupied by these timer tasks. so their rpc's callbacks can't get a thread to run.
+  # it comes to be a deadlock(timer task wait for rpc's callback to execute, and rpc's callback wait for the timer task to release the thread).
   worker_count = 8
 
 [threadpool.THREAD_POOL_REPLICATION]

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -40,7 +40,13 @@
 
 [threadpool.THREAD_POOL_DEFAULT]
   name = default
-  worker_count = 2
+  # The worker count in THREAD_POOL_DEFAULT must be >= 5.
+  # Becase in info collector server, there are four timer task(LPC_PEGASUS_APP_STAT_TIMER, LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
+  # LPC_DETECT_AVAILABLE and LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER). Each of these callbacks occupies a thread in THREAD_POOL_DEFAULT.
+  # All of these timer tasks calls remote procedure to meta server(which produce a callback), and wait for the rpc's callback to execute.
+  # If the worker_count <= 4, all of these thread are occupied by these timer tasks. so their rpc's callback can't get a thread to run.
+  # it comes to be a deadlock(timer task wait for rpc's callback to execute, and rpc's callback wait for the timer task to release the thread).
+  worker_count = 5
 
 [threadpool.THREAD_POOL_REPLICATION]
   name = replica

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -44,7 +44,7 @@
   # Because in info collector server, there are four timer task(LPC_PEGASUS_APP_STAT_TIMER, LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
   # LPC_DETECT_AVAILABLE and LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER). Each of these timer tasks occupies a thread in THREAD_POOL_DEFAULT.
   # All of these timer tasks calls remote procedure to meta server(which produce a callback), and wait for the rpc's callback to execute.
-  # If the worker_count <= 4, all of these thread are occupied by these timer tasks. so their rpc's callback can't get a thread to run.
+  # If the worker_count <= 4, all of these threads are occupied by these timer tasks. so their rpc's callbacks can't get a thread to run.
   # it comes to be a deadlock(timer task wait for rpc's callback to execute, and rpc's callback wait for the timer task to release the thread).
   worker_count = 5
 

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -41,9 +41,9 @@
 [threadpool.THREAD_POOL_DEFAULT]
   name = default
   # The worker count in THREAD_POOL_DEFAULT must be >= 5.
-  # Because in info collector server, there are four timer task(LPC_PEGASUS_APP_STAT_TIMER, LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
+  # Because in info collector server, there are four timer tasks(LPC_PEGASUS_APP_STAT_TIMER, LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
   # LPC_DETECT_AVAILABLE and LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER). Each of these timer tasks occupies a thread in THREAD_POOL_DEFAULT.
-  # All of these timer tasks calls remote procedure to meta server(which produce a callback), and wait for the rpc's callback to execute.
+  # Each of these timer task calls remote procedure to meta server(which produce a callback), and waits for the rpc's callback to execute.
   # If the worker_count <= 4, all of these threads are occupied by these timer tasks. so their rpc's callbacks can't get a thread to run.
   # it comes to be a deadlock(timer task wait for rpc's callback to execute, and rpc's callback wait for the timer task to release the thread).
   worker_count = 5

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -43,7 +43,7 @@
   # The worker count in THREAD_POOL_DEFAULT must be >= 5.
   # Because in info collector server, there are four timer tasks(LPC_PEGASUS_APP_STAT_TIMER, LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
   # LPC_DETECT_AVAILABLE and LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER). Each of these timer tasks occupies a thread in THREAD_POOL_DEFAULT.
-  # Each of these timer task calls remote procedure to meta server(which produce a callback), and waits for the rpc's callback to execute.
+  # Each of these timer tasks calls remote procedure to meta server(which produce a callback), and waits for the rpc's callback to execute.
   # If the worker_count <= 4, all of these threads are occupied by these timer tasks. so their rpc's callbacks can't get a thread to run.
   # it comes to be a deadlock(timer task wait for rpc's callback to execute, and rpc's callback wait for the timer task to release the thread).
   worker_count = 5

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -41,8 +41,8 @@
 [threadpool.THREAD_POOL_DEFAULT]
   name = default
   # The worker count in THREAD_POOL_DEFAULT must be >= 5.
-  # Becase in info collector server, there are four timer task(LPC_PEGASUS_APP_STAT_TIMER, LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
-  # LPC_DETECT_AVAILABLE and LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER). Each of these callbacks occupies a thread in THREAD_POOL_DEFAULT.
+  # Because in info collector server, there are four timer task(LPC_PEGASUS_APP_STAT_TIMER, LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
+  # LPC_DETECT_AVAILABLE and LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER). Each of these timer tasks occupies a thread in THREAD_POOL_DEFAULT.
   # All of these timer tasks calls remote procedure to meta server(which produce a callback), and wait for the rpc's callback to execute.
   # If the worker_count <= 4, all of these thread are occupied by these timer tasks. so their rpc's callback can't get a thread to run.
   # it comes to be a deadlock(timer task wait for rpc's callback to execute, and rpc's callback wait for the timer task to release the thread).

--- a/src/server/info_collector_app.h
+++ b/src/server/info_collector_app.h
@@ -11,8 +11,6 @@
 namespace pegasus {
 namespace server {
 
-DEFINE_TASK_CODE(LPC_PEGASUS_COLLECTOR_TIMER, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
-
 class info_collector_app : public ::dsn::service_app
 {
 public:


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
In info collector server, there are four timer tasks(LPC_PEGASUS_APP_STAT_TIMER, LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER, LPC_DETECT_AVAILABLE and LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER). Each of these timer task occupies a thread in THREAD_POOL_DEFAULT. Each of these timer tasks calls remote procedure to meta server(which produce a callback), and wait for the rpc's callback to execute. If the worker_count <= 4(it is 2 now), all of these threads are occupied by these timer tasks. so their rpc's callbacks can't get a thread to run. It comes to be a deadlock(timer task wait for rpc's callback to execute, and rpc's callback wait for the timer task to release the thread). 
https://github.com/XiaoMi/pegasus/issues/392

### What is changed and how it works?
change the thread count of THREAD_POOL_DEFAULT to 5

### Check List <!--REMOVE the items that are not applicable-->

Related changes
- Need to cherry-pick to the release branch
yes
- Need to update the documentation
no
- Need to be included in the release note
yes