### PR TITLE
refactor: remove the assert in get_app_stat

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -717,7 +717,9 @@ get_app_stat(shell_context *sc, const std::string &app_name, std::vector<row_dat
                 std::string counter_name;
                 bool parse_ret = parse_app_pegasus_perf_counter_name(
                     m.name, app_id_x, partition_index_x, counter_name);
-                dassert(parse_ret, "name = %s", m.name.c_str());
+                if (!parse_ret) {
+                    continue;
+                }
                 auto find = app_partitions.find(app_id_x);
                 if (find == app_partitions.end())
                     continue;

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -715,9 +715,8 @@ get_app_stat(shell_context *sc, const std::string &app_name, std::vector<row_dat
             for (dsn::perf_counter_metric &m : info.counters) {
                 int32_t app_id_x, partition_index_x;
                 std::string counter_name;
-                bool parse_ret = parse_app_pegasus_perf_counter_name(
-                    m.name, app_id_x, partition_index_x, counter_name);
-                if (!parse_ret) {
+                if (!parse_app_pegasus_perf_counter_name(
+                        m.name, app_id_x, partition_index_x, counter_name)) {
                     continue;
                 }
                 auto find = app_partitions.find(app_id_x);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Some new perf-counters were added in rdsn, which format are: `.*@app_name`. 
And in command_hepler::get_app_stat, we will get all of the perf-counters with format of `.*@.*`.
Well there is a assert to assume the string after `@` is gpid, so parsing the per-counters with format `.*@app_name` will result in info-collector server crash.

### What is changed and how it works?
remove the assert that assuming the string after '@' is gpid

### Check List <!--REMOVE the items that are not applicable-->

Related changes
- Need to cherry-pick to the release branch
yes
- Need to update the documentation
no
- Need to be included in the release note
no