### PR TITLE
feat: add a interface to get perf-counters info of all partitions of all apps

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -710,7 +710,7 @@ inline bool get_app_partition_stat(shell_context *sc,
             auto find = app_partitions.find(app_id_x);
             if (find != app_partitions.end() &&
                 find->second[partition_index_x].primary == nodes[i].address) {
-                const std::string app_name = app_id_name[app_id_x];
+                const std::string &app_name = app_id_name[app_id_x];
                 row_data &row = rows[app_name][partition_index_x];
                 row.row_name = std::to_string(partition_index_x);
                 row.app_id = app_id_x;

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -710,8 +710,11 @@ inline bool get_app_partition_stat(shell_context *sc,
             auto find = app_partitions.find(app_id_x);
             if (find != app_partitions.end() &&
                 find->second[partition_index_x].primary == nodes[i].address) {
-                update_app_pegasus_perf_counter(
-                    rows[app_id_name[app_id_x]][partition_index_x], counter_name, m.value);
+                const std::string app_name = app_id_name[app_id_x];
+                row_data &row = rows[app_name][partition_index_x];
+                row.row_name = std::to_string(partition_index_x);
+                row.app_id = app_id_x;
+                update_app_pegasus_perf_counter(row, counter_name, m.value);
             }
         }
     }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
There is no interface to supply perf-counters of all partitions of all apps

### What is changed and how it works?
Add a interface(get_app_partition_stat) to get perf-counters of all partitions of all apps.

### Check List <!--REMOVE the items that are not applicable-->
Related changes
- Need to cherry-pick to the release branch
yes
- Need to update the documentation
no
- Need to be included in the release note
no