### PR TITLE
feat(shell): add qps and p99 statistics while list_node

### DIFF
--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -51,10 +51,10 @@ struct list_nodes_helper
     double put_qps = 0;
     double multi_get_qps = 0;
     double multi_put_qps = 0;
-    int64_t get_p99 = 0;
-    int64_t put_p99 = 0;
-    int64_t multi_get_p99 = 0;
-    int64_t multi_put_p99 = 0;
+    double get_p99 = 0;
+    double put_p99 = 0;
+    double multi_get_p99 = 0;
+    double multi_put_p99 = 0;
     list_nodes_helper(const std::string &n, const std::string &s)
         : node_name(n),
           node_status(s),

--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -47,14 +47,14 @@ struct list_nodes_helper
     int64_t mem_idx_bytes;
     int64_t disk_available_total_ratio;
     int64_t disk_available_min_ratio;
-    double get_qps = 0;
-    double put_qps = 0;
-    double multi_get_qps = 0;
-    double multi_put_qps = 0;
-    double get_p99 = 0;
-    double put_p99 = 0;
-    double multi_get_p99 = 0;
-    double multi_put_p99 = 0;
+    double get_qps;
+    double put_qps;
+    double multi_get_qps;
+    double multi_put_qps;
+    double get_p99;
+    double put_p99;
+    double multi_get_p99;
+    double multi_put_p99;
     list_nodes_helper(const std::string &n, const std::string &s)
         : node_name(n),
           node_status(s),
@@ -66,14 +66,14 @@ struct list_nodes_helper
           mem_idx_bytes(0),
           disk_available_total_ratio(0),
           disk_available_min_ratio(0),
-          get_qps(0),
-          put_qps(0),
-          multi_get_qps(0),
-          multi_put_qps(0),
-          get_p99(0),
-          put_p99(0),
-          multi_get_p99(0),
-          multi_put_p99(0)
+          get_qps(0.0),
+          put_qps(0.0),
+          multi_get_qps(0.0),
+          multi_put_qps(0.0),
+          get_p99(0.0),
+          put_p99(0.0),
+          multi_get_p99(0.0),
+          multi_put_p99(0.0)
     {
     }
 };

--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -47,6 +47,14 @@ struct list_nodes_helper
     int64_t mem_idx_bytes;
     int64_t disk_available_total_ratio;
     int64_t disk_available_min_ratio;
+    double get_qps = 0;
+    double put_qps = 0;
+    double multi_get_qps = 0;
+    double multi_put_qps = 0;
+    int64_t get_p99 = 0;
+    int64_t put_p99 = 0;
+    int64_t multi_get_p99 = 0;
+    int64_t multi_put_p99 = 0;
     list_nodes_helper(const std::string &n, const std::string &s)
         : node_name(n),
           node_status(s),
@@ -57,7 +65,15 @@ struct list_nodes_helper
           mem_tbl_bytes(0),
           mem_idx_bytes(0),
           disk_available_total_ratio(0),
-          disk_available_min_ratio(0)
+          disk_available_min_ratio(0),
+          get_qps(0),
+          put_qps(0),
+          multi_get_qps(0),
+          multi_put_qps(0),
+          get_p99(0),
+          put_p99(0),
+          multi_get_p99(0),
+          multi_put_p99(0)
     {
     }
 };

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -240,7 +240,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
         }
 
         ::dsn::command command;
-        command.cmd = "perf-counters";
+        command.cmd = "perf-counters-by-postfix";
         command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_GET.qps");
         command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_PUT.qps");
         command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_MULTI_GET.qps");
@@ -355,10 +355,10 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             tp.append_data(kv.second.put_qps);
             tp.append_data(kv.second.multi_get_qps);
             tp.append_data(kv.second.multi_put_qps);
-            tp.append_data(kv.second.get_p99 / 1000);
-            tp.append_data(kv.second.put_p99 / 1000);
-            tp.append_data(kv.second.multi_get_p99 / 1000);
-            tp.append_data(kv.second.multi_put_p99 / 1000);
+            tp.append_data(kv.second.get_p99 / 1000000);
+            tp.append_data(kv.second.put_p99 / 1000000);
+            tp.append_data(kv.second.multi_get_p99 / 1000000);
+            tp.append_data(kv.second.multi_put_p99 / 1000000);
         }
     }
     mtp.add(std::move(tp));

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -240,7 +240,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
         }
 
         ::dsn::command command;
-        command.cmd = "perf-counters-by-prefix";
+        command.cmd = "perf-counters";
         command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_GET.qps");
         command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_PUT.qps");
         command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_MULTI_GET.qps");

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -48,6 +48,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
     static struct option long_options[] = {{"detailed", no_argument, 0, 'd'},
                                            {"resolve_ip", no_argument, 0, 'r'},
                                            {"resource_usage", no_argument, 0, 'u'},
+                                           {"qps", no_argument, 0, 'q'},
                                            {"json", no_argument, 0, 'j'},
                                            {"status", required_argument, 0, 's'},
                                            {"output", required_argument, 0, 'o'},
@@ -58,12 +59,13 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
     bool detailed = false;
     bool resolve_ip = false;
     bool resource_usage = false;
+    bool show_qps = false;
     bool json = false;
     optind = 0;
     while (true) {
         int option_index = 0;
         int c;
-        c = getopt_long(args.argc, args.argv, "drujs:o:", long_options, &option_index);
+        c = getopt_long(args.argc, args.argv, "druqjs:o:", long_options, &option_index);
         if (c == -1)
             break;
         switch (c) {
@@ -75,6 +77,9 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             break;
         case 'u':
             resource_usage = true;
+            break;
+        case 'q':
+            show_qps = true;
             break;
         case 'j':
             json = true;
@@ -227,6 +232,70 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
         }
     }
 
+    if (show_qps) {
+        std::vector<node_desc> nodes;
+        if (!fill_nodes(sc, "replica-server", nodes)) {
+            std::cout << "get replica server node list failed" << std::endl;
+            return true;
+        }
+
+        ::dsn::command command;
+        command.cmd = "perf-counters-by-prefix";
+        command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_GET.qps");
+        command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_PUT.qps");
+        command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_MULTI_GET.qps");
+        command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_MULTI_PUT.qps");
+        command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_GET.latency.server");
+        command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_PUT.latency.server");
+        command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_MULTI_GET.latency.server");
+        command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_MULTI_PUT.latency.server");
+        std::vector<std::pair<bool, std::string>> results;
+        call_remote_command(sc, nodes, command, results);
+
+        for (int i = 0; i < nodes.size(); ++i) {
+            dsn::rpc_address node_addr = nodes[i].address;
+            auto tmp_it = tmp_map.find(node_addr);
+            if (tmp_it == tmp_map.end())
+                continue;
+            if (!results[i].first) {
+                std::cout << "query perf counter info from node " << node_addr.to_string()
+                          << " failed" << std::endl;
+                return true;
+            }
+            dsn::perf_counter_info info;
+            dsn::blob bb(results[i].second.data(), 0, results[i].second.size());
+            if (!dsn::json::json_forwarder<dsn::perf_counter_info>::decode(bb, info)) {
+                std::cout << "decode perf counter info from node " << node_addr.to_string()
+                          << " failed, result = " << results[i].second << std::endl;
+                return true;
+            }
+            if (info.result != "OK") {
+                std::cout << "query perf counter info from node " << node_addr.to_string()
+                          << " returns error, error = " << info.result << std::endl;
+                return true;
+            }
+            list_nodes_helper &h = tmp_it->second;
+            for (dsn::perf_counter_metric &m : info.counters) {
+                if (m.name.find("RPC_RRDB_RRDB_GET.qps") != std::string::npos)
+                    h.get_qps += m.value;
+                else if (m.name.find("RPC_RRDB_RRDB_PUT.qps") != std::string::npos)
+                    h.put_qps += m.value;
+                else if (m.name.find("RPC_RRDB_RRDB_MULTI_GET.qps") != std::string::npos)
+                    h.multi_get_qps += m.value;
+                else if (m.name.find("RPC_RRDB_RRDB_MULTI_PUT.qps") != std::string::npos)
+                    h.put_qps += m.value;
+                else if (m.name.find("RPC_RRDB_RRDB_GET.latency.server") != std::string::npos)
+                    h.get_p99 += m.value;
+                else if (m.name.find("RPC_RRDB_RRDB_PUT.latency.server") != std::string::npos)
+                    h.put_p99 += m.value;
+                else if (m.name.find("RPC_RRDB_RRDB_MULTI_GET.latency.server") != std::string::npos)
+                    h.multi_get_p99 += m.value;
+                else if (m.name.find("RPC_RRDB_RRDB_MULTI_PUT.latency.server") != std::string::npos)
+                    h.multi_put_p99 += m.value;
+            }
+        }
+    }
+
     // print configuration_list_nodes_response
     std::streambuf *buf;
     std::ofstream of;
@@ -255,6 +324,16 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
         tp.add_column("disk_avl_total_ratio", tp_alignment::kRight);
         tp.add_column("disk_avl_min_ratio", tp_alignment::kRight);
     }
+    if (show_qps) {
+        tp.add_column("get_qps", tp_alignment::kRight);
+        tp.add_column("put_qps", tp_alignment::kRight);
+        tp.add_column("mget_qps", tp_alignment::kRight);
+        tp.add_column("mput_qps", tp_alignment::kRight);
+        tp.add_column("get_p99(ms)", tp_alignment::kRight);
+        tp.add_column("put_p99(ms)", tp_alignment::kRight);
+        tp.add_column("mget_p99(ms)", tp_alignment::kRight);
+        tp.add_column("mput_p99(ms)", tp_alignment::kRight);
+    }
     for (auto &kv : tmp_map) {
         tp.add_row(kv.second.node_name);
         tp.append_data(kv.second.node_status);
@@ -270,6 +349,16 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             tp.append_data(kv.second.mem_idx_bytes / (1 << 20U));
             tp.append_data(kv.second.disk_available_total_ratio);
             tp.append_data(kv.second.disk_available_min_ratio);
+        }
+        if (show_qps) {
+            tp.append_data(kv.second.get_qps);
+            tp.append_data(kv.second.put_qps);
+            tp.append_data(kv.second.multi_get_qps);
+            tp.append_data(kv.second.multi_put_qps);
+            tp.append_data(kv.second.get_p99 / 1000);
+            tp.append_data(kv.second.put_p99 / 1000);
+            tp.append_data(kv.second.multi_get_p99 / 1000);
+            tp.append_data(kv.second.multi_put_p99 / 1000);
         }
     }
     mtp.add(std::move(tp));

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -239,6 +239,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             return true;
         }
 
+        // TODO(heyuchen): add cu statistics
         ::dsn::command command;
         command.cmd = "perf-counters-by-postfix";
         command.arguments.push_back("zion*profiler*RPC_RRDB_RRDB_GET.qps");
@@ -277,21 +278,21 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
             list_nodes_helper &h = tmp_it->second;
             for (dsn::perf_counter_metric &m : info.counters) {
                 if (m.name.find("RPC_RRDB_RRDB_GET.qps") != std::string::npos)
-                    h.get_qps += m.value;
+                    h.get_qps = m.value;
                 else if (m.name.find("RPC_RRDB_RRDB_PUT.qps") != std::string::npos)
-                    h.put_qps += m.value;
+                    h.put_qps = m.value;
                 else if (m.name.find("RPC_RRDB_RRDB_MULTI_GET.qps") != std::string::npos)
-                    h.multi_get_qps += m.value;
+                    h.multi_get_qps = m.value;
                 else if (m.name.find("RPC_RRDB_RRDB_MULTI_PUT.qps") != std::string::npos)
-                    h.put_qps += m.value;
+                    h.put_qps = m.value;
                 else if (m.name.find("RPC_RRDB_RRDB_GET.latency.server") != std::string::npos)
-                    h.get_p99 += m.value;
+                    h.get_p99 = m.value;
                 else if (m.name.find("RPC_RRDB_RRDB_PUT.latency.server") != std::string::npos)
-                    h.put_p99 += m.value;
+                    h.put_p99 = m.value;
                 else if (m.name.find("RPC_RRDB_RRDB_MULTI_GET.latency.server") != std::string::npos)
-                    h.multi_get_p99 += m.value;
+                    h.multi_get_p99 = m.value;
                 else if (m.name.find("RPC_RRDB_RRDB_MULTI_PUT.latency.server") != std::string::npos)
-                    h.multi_put_p99 += m.value;
+                    h.multi_put_p99 = m.value;
             }
         }
     }
@@ -326,12 +327,12 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
     }
     if (show_qps) {
         tp.add_column("get_qps", tp_alignment::kRight);
-        tp.add_column("put_qps", tp_alignment::kRight);
-        tp.add_column("mget_qps", tp_alignment::kRight);
-        tp.add_column("mput_qps", tp_alignment::kRight);
         tp.add_column("get_p99(ms)", tp_alignment::kRight);
-        tp.add_column("put_p99(ms)", tp_alignment::kRight);
+        tp.add_column("mget_qps", tp_alignment::kRight);
         tp.add_column("mget_p99(ms)", tp_alignment::kRight);
+        tp.add_column("put_qps", tp_alignment::kRight);
+        tp.add_column("put_p99(ms)", tp_alignment::kRight);
+        tp.add_column("mput_qps", tp_alignment::kRight);
         tp.add_column("mput_p99(ms)", tp_alignment::kRight);
     }
     for (auto &kv : tmp_map) {
@@ -352,12 +353,12 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
         }
         if (show_qps) {
             tp.append_data(kv.second.get_qps);
-            tp.append_data(kv.second.put_qps);
-            tp.append_data(kv.second.multi_get_qps);
-            tp.append_data(kv.second.multi_put_qps);
             tp.append_data(kv.second.get_p99 / 1000000);
-            tp.append_data(kv.second.put_p99 / 1000000);
+            tp.append_data(kv.second.multi_get_qps);
             tp.append_data(kv.second.multi_get_p99 / 1000000);
+            tp.append_data(kv.second.put_qps);
+            tp.append_data(kv.second.put_p99 / 1000000);
+            tp.append_data(kv.second.multi_put_qps);
             tp.append_data(kv.second.multi_put_p99 / 1000000);
         }
     }

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -60,7 +60,7 @@ static command_executor commands[] = {
         "nodes",
         "get the node status for this cluster",
         "[-d|--detailed] [-j|--json] [-r|--resolve_ip] [-u|--resource_usage]"
-        "[-o|--output file_name] [-s|--status all|alive|unalive]",
+        "[-o|--output file_name] [-s|--status all|alive|unalive] [-q|--qps]",
         ls_nodes,
     },
     {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
We used to get server basic qps and latency information by command `server_stat`. However,  `server_stat` is hard to read, and some memory-related statistics have already be shown by command `nodes -u`. As a result, I add command `nodes -q` to show qps and latency information provided by `server_stat`.

### What is changed and how it works?
Add command `nodes -q` to show server read, write qps and read, write latency.
The command sample is below:
```
>>> nodes -q
[details]
address   status    get_qps  get_p99(ms)  mget_qps  mget_p99(ms)  put_qps  put_p99(ms)  mput_qps  mput_p99(ms)
host1     ALIVE       23.86         0.13     86.63          0.44    42.57         3.27      0.00          0.00
host2     ALIVE       18.61         0.12     99.69          0.52     0.00         3.20      0.00          0.00
host3     ALIVE       21.88         0.16     58.71          0.59     0.00         3.54      0.00          0.00
host4     ALIVE       17.32         0.10     74.54          0.50    25.74         3.23      0.00          0.00
host5     ALIVE       21.08         0.11     99.95          0.52    27.51         0.92      0.00          0.00

[summary]
total_node_count    : 5
alive_node_count    : 5
unalive_node_count  : 0

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Manual test
