### PR TITLE
feat: add http_server for info collector

### DIFF
--- a/src/server/info_collector_app.cpp
+++ b/src/server/info_collector_app.cpp
@@ -16,7 +16,7 @@ namespace pegasus {
 namespace server {
 
 info_collector_app::info_collector_app(const dsn::service_app_info *info)
-    : service_app(info), _updater_started(false)
+    : service_app(info), _updater_started(false), _http_server(new ::dsn::http_server())
 {
 }
 

--- a/src/server/info_collector_app.h
+++ b/src/server/info_collector_app.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <dsn/cpp/service_app.h>
+#include <dsn/tool-api/http_server.h>
 #include "info_collector.h"
 #include "available_detector.h"
 
@@ -24,6 +25,7 @@ private:
     info_collector _collector;
     available_detector _detector;
     bool _updater_started;
+    std::unique_ptr<::dsn::http_server> _http_server;
 };
 }
 } // namespace


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
HTTP is not supported in info collector now, so we can't get some info from info collector through http request

### What is changed and how it works?
Add http_server for info collector

- Need to cherry-pick to the release branch

