### PR TITLE
refactor: update rdsn and remove DSN_CORE_VERSION

### DIFF
--- a/src/client_lib/pegasus_client_factory_impl.cpp
+++ b/src/client_lib/pegasus_client_factory_impl.cpp
@@ -68,7 +68,6 @@ pegasus_client *pegasus_client_factory_impl::get_client(const char *cluster_name
 #if defined(__linux__)
 #include <pegasus/version.h>
 #include <pegasus/git_commit.h>
-#include <dsn/version.h>
 #include <dsn/git_commit.h>
 #define STR_I(var) #var
 #define STR(var) STR_I(var)
@@ -77,7 +76,7 @@ static char const rcsid[] =
 #if defined(DSN_BUILD_TYPE)
     " " STR(DSN_BUILD_TYPE)
 #endif
-        ", built with rDSN " DSN_CORE_VERSION " (" DSN_GIT_COMMIT ")"
+        ", built with rDSN (" DSN_GIT_COMMIT ")"
         ", built by gcc " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
 #if defined(DSN_BUILD_HOSTNAME)
             ", built on " STR(DSN_BUILD_HOSTNAME)

--- a/src/client_lib/pegasus_client_factory_impl.cpp
+++ b/src/client_lib/pegasus_client_factory_impl.cpp
@@ -64,23 +64,3 @@ pegasus_client *pegasus_client_factory_impl::get_client(const char *cluster_name
 }
 }
 } // namespace
-
-#if defined(__linux__)
-#include <pegasus/version.h>
-#include <pegasus/git_commit.h>
-#include <dsn/git_commit.h>
-#define STR_I(var) #var
-#define STR(var) STR_I(var)
-static char const rcsid[] =
-    "$Version: Pegasus Client " PEGASUS_VERSION " (" PEGASUS_GIT_COMMIT ")"
-#if defined(DSN_BUILD_TYPE)
-    " " STR(DSN_BUILD_TYPE)
-#endif
-        ", built with rDSN (" DSN_GIT_COMMIT ")"
-        ", built by gcc " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
-#if defined(DSN_BUILD_HOSTNAME)
-            ", built on " STR(DSN_BUILD_HOSTNAME)
-#endif
-                ", built at " __DATE__ " " __TIME__ " $";
-const char *pegasus_client_rcsid() { return rcsid; }
-#endif

--- a/src/redis_protocol/proxy/main.cpp
+++ b/src/redis_protocol/proxy/main.cpp
@@ -79,23 +79,3 @@ int main(int argc, char **argv)
     }
     return 0;
 }
-
-#if defined(__linux__)
-#include <pegasus/version.h>
-#include <pegasus/git_commit.h>
-#include <dsn/git_commit.h>
-#define STR_I(var) #var
-#define STR(var) STR_I(var)
-static char const rcsid[] =
-    "$Version: Pegasus Redis Proxy " PEGASUS_VERSION " (" PEGASUS_GIT_COMMIT ")"
-#if defined(DSN_BUILD_TYPE)
-    " " STR(DSN_BUILD_TYPE)
-#endif
-        ", built with rDSN (" DSN_GIT_COMMIT ")"
-        ", built by gcc " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
-#if defined(DSN_BUILD_HOSTNAME)
-            ", built on " STR(DSN_BUILD_HOSTNAME)
-#endif
-                ", built at " __DATE__ " " __TIME__ " $";
-const char *pegasus_rproxy_rcsid() { return rcsid; }
-#endif

--- a/src/redis_protocol/proxy/main.cpp
+++ b/src/redis_protocol/proxy/main.cpp
@@ -83,7 +83,6 @@ int main(int argc, char **argv)
 #if defined(__linux__)
 #include <pegasus/version.h>
 #include <pegasus/git_commit.h>
-#include <dsn/version.h>
 #include <dsn/git_commit.h>
 #define STR_I(var) #var
 #define STR(var) STR_I(var)
@@ -92,7 +91,7 @@ static char const rcsid[] =
 #if defined(DSN_BUILD_TYPE)
     " " STR(DSN_BUILD_TYPE)
 #endif
-        ", built with rDSN " DSN_CORE_VERSION " (" DSN_GIT_COMMIT ")"
+        ", built with rDSN (" DSN_GIT_COMMIT ")"
         ", built by gcc " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
 #if defined(DSN_BUILD_HOSTNAME)
             ", built on " STR(DSN_BUILD_HOSTNAME)

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -7,7 +7,6 @@
 #include "info_collector_app.h"
 #include "brief_stat.h"
 
-#include <dsn/version.h>
 #include <dsn/git_commit.h>
 #include <pegasus/version.h>
 #include <pegasus/git_commit.h>
@@ -38,7 +37,7 @@ static char const rcsid[] =
 #if defined(DSN_BUILD_TYPE)
     " " STR(DSN_BUILD_TYPE)
 #endif
-        ", built with rDSN " DSN_CORE_VERSION " (" DSN_GIT_COMMIT ")"
+        ", built with rDSN (" DSN_GIT_COMMIT ")"
         ", built by gcc " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
 #if defined(DSN_BUILD_HOSTNAME)
             ", built on " STR(DSN_BUILD_HOSTNAME)

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -644,7 +644,6 @@ int main(int argc, char **argv)
 }
 
 #include <dsn/git_commit.h>
-#include <dsn/version.h>
 #include <pegasus/git_commit.h>
 #include <pegasus/version.h>
 static char const rcsid[] =
@@ -652,7 +651,7 @@ static char const rcsid[] =
 #if defined(DSN_BUILD_TYPE)
     " " STR(DSN_BUILD_TYPE)
 #endif
-        ", built with rDSN " DSN_CORE_VERSION " (" DSN_GIT_COMMIT ")"
+        ", built with rDSN (" DSN_GIT_COMMIT ")"
         ", built by gcc " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
 #if defined(DSN_BUILD_HOSTNAME)
             ", built on " STR(DSN_BUILD_HOSTNAME)

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -642,19 +642,3 @@ int main(int argc, char **argv)
     run();
     return 0;
 }
-
-#include <dsn/git_commit.h>
-#include <pegasus/git_commit.h>
-#include <pegasus/version.h>
-static char const rcsid[] =
-    "$Version: Pegasus Shell " PEGASUS_VERSION " (" PEGASUS_GIT_COMMIT ")"
-#if defined(DSN_BUILD_TYPE)
-    " " STR(DSN_BUILD_TYPE)
-#endif
-        ", built with rDSN (" DSN_GIT_COMMIT ")"
-        ", built by gcc " STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
-#if defined(DSN_BUILD_HOSTNAME)
-            ", built on " STR(DSN_BUILD_HOSTNAME)
-#endif
-                ", built at " __DATE__ " " __TIME__ " $";
-const char *pegasus_shell_rcsid() { return rcsid; }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

According to https://github.com/XiaoMi/rdsn/pull/379, we removed `DSN_CORE_VERSION`.
But this macro still has some usages on Pegasus side, we should remove them as well.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Related changes

- Need to cherry-pick to the release branch
