### PR TITLE
refactor(config): remove duplicated config items for cluster name

### DIFF
--- a/src/reporter/pegasus_counter_reporter.cpp
+++ b/src/reporter/pegasus_counter_reporter.cpp
@@ -8,11 +8,9 @@
 #include <ios>
 #include <iomanip>
 #include <iostream>
-#include <fstream>
 
 #include <unistd.h>
 
-#include <dsn/utility/smart_pointers.h>
 #include <dsn/cpp/service_app.h>
 #include <dsn/dist/replication/duplication_common.h>
 
@@ -23,10 +21,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <thread>
-#include <sstream>
-#include <iterator>
-#include <regex>
 
 using namespace ::dsn;
 

--- a/src/reporter/pegasus_counter_reporter.cpp
+++ b/src/reporter/pegasus_counter_reporter.cpp
@@ -14,6 +14,7 @@
 
 #include <dsn/utility/smart_pointers.h>
 #include <dsn/cpp/service_app.h>
+#include <dsn/dist/replication/duplication_common.h>
 
 #include "base/pegasus_utils.h"
 #include "pegasus_io_service.h"
@@ -140,9 +141,7 @@ void pegasus_counter_reporter::start()
 
     _app_name = dsn::service_app::current_service_app_info().full_name;
 
-    _cluster_name = dsn_config_get_value_string(
-        "pegasus.server", "perf_counter_cluster_name", "", "perf_counter_cluster_name");
-    dassert(_cluster_name.size() > 0, "");
+    _cluster_name = dsn::replication::get_current_cluster_name();
 
     _update_interval_seconds = dsn_config_get_value_uint64("pegasus.server",
                                                            "perf_counter_update_interval_seconds",
@@ -355,5 +354,5 @@ void pegasus_counter_reporter::on_report_timer(std::shared_ptr<boost::asio::dead
         dassert(false, "pegasus report timer error!!!");
     }
 }
-}
-} // namespace
+} // namespace server
+} // namespace pegasus

--- a/src/server/available_detector.cpp
+++ b/src/server/available_detector.cpp
@@ -7,6 +7,7 @@
 #include <iomanip>
 #include <algorithm>
 #include <sstream>
+#include <dsn/dist/replication/duplication_common.h>
 
 #include "base/pegasus_key_schema.h"
 #include "result_writer.h"
@@ -29,8 +30,7 @@ available_detector::available_detector()
       _recent_minute_fail_times(0)
 {
     // initialize information for available_detector.
-    _cluster_name = dsn_config_get_value_string("pegasus.collector", "cluster", "", "cluster name");
-    dassert(_cluster_name.size() > 0, "");
+    _cluster_name = dsn::replication::get_current_cluster_name();
     _app_name = dsn_config_get_value_string(
         "pegasus.collector", "available_detect_app", "", "available detector app name");
     dassert(_app_name.size() > 0, "");

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -287,7 +287,6 @@
 
   manual_compact_min_interval_seconds = 600
 
-  perf_counter_cluster_name = %{cluster.name}
   perf_counter_update_interval_seconds = 10
   perf_counter_enable_logging = false
   perf_counter_enable_falcon = false
@@ -303,8 +302,6 @@
   prometheus_port = 9091
 
 [pegasus.collector]
-  cluster = %{cluster.name}
-
   available_detect_app = temp
   available_detect_alert_script_dir = ./package/bin
   available_detect_alert_email_address =

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -100,6 +100,7 @@
   mutation_2pc_min_replica_count = 1
   cold_backup_root = onebox
   duplication_disabled = true
+  cluster_name = onebox
 
 [meta_server.apps.@APP_NAME@]
   app_name = @APP_NAME@
@@ -112,12 +113,9 @@
   partition_count = 4
 
 [pegasus.server]
-  perf_counter_cluster_name = onebox
   perf_counter_enable_logging = false
 
 [pegasus.collector]
-  cluster = onebox
-
   available_detect_app = @APP_NAME@
   available_detect_alert_script_dir = ./package/bin
   usage_stat_app = stat

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -6,17 +6,13 @@
 
 #include <cstdlib>
 #include <iomanip>
-#include <iostream>
 #include <vector>
 #include <chrono>
-#include <functional>
 #include <dsn/tool-api/group_address.h>
+#include <dsn/dist/replication/duplication_common.h>
 
-#include "base/pegasus_utils.h"
 #include "base/pegasus_const.h"
 #include "result_writer.h"
-
-#define METRICSNUM 3
 
 using namespace ::dsn;
 using namespace ::dsn::replication;
@@ -42,8 +38,7 @@ info_collector::info_collector()
         _meta_servers.group_address()->add(ms);
     }
 
-    _cluster_name = dsn_config_get_value_string("pegasus.collector", "cluster", "", "cluster name");
-    dassert(!_cluster_name.empty(), "");
+    _cluster_name = dsn::replication::get_current_cluster_name();
 
     _shell_context.current_cluster_name = _cluster_name;
     _shell_context.meta_list = meta_servers;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, there are 3 places defining the cluster name:

- `[pegasus.collector] cluster = onebox`
- `[pegasus.server] perf_counter_cluster_name = onebox`
- `[replication] cluster_name = onebox`

Since both the rdsn module and pegasus need "cluster_name", we can use the common util
`dsn::replication::get_current_cluster_name` to retrieve this config (by reading `[replication] cluster_name`), instead of reading config in separate places.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```sh
> ./run.sh start_onebox -r 3 -m 2 -c # start collector as well, use config.min.ini
> ./run.sh list_onebox # no coredump
wutao1   25359     1  0 17:10 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/collector/pegasus_server config.ini -app_list collector
wutao1   25136     1  0 17:10 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/meta1/pegasus_server config.ini -app_list meta
wutao1   25152     1  0 17:10 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/meta2/pegasus_server config.ini -app_list meta
wutao1   25188     1  0 17:10 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/replica1/pegasus_server config.ini -app_list replica
wutao1   25233     1  0 17:10 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/replica2/pegasus_server config.ini -app_list replica
wutao1   25277     1  0 17:10 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/replica3/pegasus_server config.ini -app_list replica

> ./run.sh start_onebox -r 3 -m 2 -c --use_product_config  # use config.ini               
> ./run.sh list_onebox # no coredump
wutao1   27745     1  0 17:14 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/collector/pegasus_server config.ini -app_list collector
wutao1   27219     1  0 17:14 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/meta1/pegasus_server config.ini -app_list meta
wutao1   27229     1  0 17:14 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/meta2/pegasus_server config.ini -app_list meta
wutao1   27313     1  0 17:14 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/replica1/pegasus_server config.ini -app_list replica
wutao1   27408     1  0 17:14 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/replica2/pegasus_server config.ini -app_list replica
wutao1   27575     1  0 17:14 pts/4    00:00:00 /home/wutao1/git/release/pegasus/onebox/replica3/pegasus_server config.ini -app_list replica
```

Side effects

- Configuration changes:

```ini
[pegasus.collector]
- cluster = %{cluster.name}
[pegasus.server]
- perf_counter_cluster_name = %{cluster.name}
[replication]
+ cluster_name = %{cluster.name}
```

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
