### PR TITLE
feat(split): add partition_version

### DIFF
--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2768,7 +2768,8 @@ std::string pegasus_server_impl::query_compact_state() const
 
 void pegasus_server_impl::set_partition_version(uint32_t partition_version)
 {
-    ddebug_replica("update partition version from {} to {}", _partition_version.load(), partition_version);
+    ddebug_replica(
+        "update partition version from {} to {}", _partition_version.load(), partition_version);
     _partition_version.store(partition_version);
 
     // TODO(heyuchen): set filter _partition_version in further pr

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -56,7 +56,8 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
       _pegasus_data_version(PEGASUS_DATA_VERSION_MAX),
       _last_durable_decree(0),
       _is_checkpointing(false),
-      _manual_compact_svc(this)
+      _manual_compact_svc(this),
+      _partition_version(0)
 {
     _primary_address = dsn::rpc_address(dsn_primary_address()).to_string();
     _gpid = get_gpid();
@@ -2763,6 +2764,14 @@ bool pegasus_server_impl::release_storage_after_manual_compact()
 std::string pegasus_server_impl::query_compact_state() const
 {
     return _manual_compact_svc.query_compact_state();
+}
+
+void pegasus_server_impl::set_partition_version(uint32_t partition_version)
+{
+    ddebug_replica("update partition version from {} to {}", _partition_version.load(), partition_version);
+    _partition_version.store(partition_version);
+
+    // TODO(heyuchen): set filter _partition_version in further pr
 }
 
 } // namespace server

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2777,9 +2777,9 @@ std::string pegasus_server_impl::query_compact_state() const
 
 void pegasus_server_impl::set_partition_version(int32_t partition_version)
 {
+    int32_t old_partition_version = _partition_version.exchange(partition_version);
     ddebug_replica(
-        "update partition version from {} to {}", _partition_version.load(), partition_version);
-    _partition_version.store(partition_version);
+        "update partition version from {} to {}", old_partition_version, partition_version);
 
     // TODO(heyuchen): set filter _partition_version in further pr
 }

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -153,6 +153,8 @@ public:
 
     virtual void query_app_envs(/*out*/ std::map<std::string, std::string> &envs) override;
 
+    virtual void set_partition_version(uint32_t partition_version) override;
+
 private:
     friend class manual_compact_service_test;
     friend class pegasus_compression_options_test;
@@ -339,6 +341,8 @@ private:
     static ::dsn::task_ptr _update_server_rdb_stat;
 
     pegasus_manual_compact_service _manual_compact_svc;
+
+    std::atomic<uint32_t> _partition_version;
 
     dsn::task_tracker _tracker;
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Add definition of `partition_version`, used for partition split to guarantee data consistency. 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Unit test

Related changes
- Need to cherry-pick to the release branch
