### PR TITLE
fix: add libraries missing for pegasus_client_shared

### DIFF
--- a/src/client_lib/CMakeLists.txt
+++ b/src/client_lib/CMakeLists.txt
@@ -36,5 +36,7 @@ add_library(pegasus_client_shared SHARED $<TARGET_OBJECTS:pegasus_client_impl_ob
 target_link_libraries(pegasus_client_shared PRIVATE
     pegasus_base
     dsn_runtime
+    dsn_replication_client
+    dsn_replication_common
     thrift)
 install(TARGETS pegasus_client_shared DESTINATION "lib")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Our user reported that pegasus_client_shared had some libraries missing, which I found are
-    dsn_replication_client
-    dsn_replication_common

They are already linked to pegasus_client_static, but not to pegasus_client_shared.
This PR has been confirmed to work on our user's environment.
