### PR TITLE
fix: use db when it has been opened

### DIFF
--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -415,7 +415,14 @@ void pegasus_server_impl::parse_checkpoints()
     }
 }
 
-pegasus_server_impl::~pegasus_server_impl() = default;
+pegasus_server_impl::~pegasus_server_impl()
+{
+    if (_is_open) {
+        dassert(_db != nullptr, "");
+        delete _db;
+        _db = nullptr;
+    }
+}
 
 void pegasus_server_impl::gc_checkpoints(bool force_reserve_one)
 {
@@ -1665,8 +1672,10 @@ void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache
 
 void pegasus_server_impl::cancel_background_work(bool wait)
 {
-    dassert(_db != nullptr, "");
-    rocksdb::CancelAllBackgroundWork(_db, wait);
+    if (_is_open) {
+        dassert(_db != nullptr, "");
+        rocksdb::CancelAllBackgroundWork(_db, wait);
+    }
 }
 
 ::dsn::error_code pegasus_server_impl::stop(bool clear_state)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
- It's a bug to call `rocksdb::CancelAllBackgroundWork` when close replica after db open failed
- Explicitly delete db in pegasus_server_impl's destructor

### What is changed and how it works?
No related.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
No
- Integration test
No
- Manual test (add detailed scripts or steps below)
Yes
- No code
No

Code changes

- Has exported function/method change
No
- Has exported variable/fields change
No
- Has interface methods change
No
- Has persistent data change
No

Side effects

- Possible performance regression
No
- Increased code complexity
No
- Breaking backward compatibility
No

Related changes

- Need to cherry-pick to the release branch
Yes
- Need to update the documentation
No
- Need to be included in the release note
No