### PR TITLE
feat: support of getting backup request perf-counter in command_helper

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -757,7 +757,7 @@ inline bool get_app_partition_stat(shell_context *sc,
                     row.app_id = app_id_x;
                     update_app_pegasus_perf_counter(row, counter_name, m.value);
                 }
-            } else if (parse_app_perf_counter_name(m.name, app_name,counter_name)) {
+            } else if (parse_app_perf_counter_name(m.name, app_name, counter_name)) {
                 // perf-counter value will be set into partition index 0.
                 row_data &row = rows[app_name][0];
                 row.app_id = app_name_id[app_name];


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
support of getting backup request perf-counter in command_helper

### What is changed and how it works?
Using function get_app_partition_stat, we can get backup_request_qps for each app.

Related changes

- Need to cherry-pick to the release branch
