### PR TITLE
fix(shell): disk_replica printer bug

### DIFF
--- a/src/shell/commands/disk_rebalance.cpp
+++ b/src/shell/commands/disk_rebalance.cpp
@@ -247,9 +247,8 @@ bool query_disk_replica(command_executor *e, shell_context *sc, arguments args)
             disk_printer.append_data(primary_count);
             disk_printer.append_data(secondary_count);
             disk_printer.append_data(primary_count + secondary_count);
-
-            multi_printer.add(std::move(disk_printer));
         }
+        multi_printer.add(std::move(disk_printer));
     }
     multi_printer.output(
         *out.stream(), format_to_json ? tp_output_format::kJsonPretty : tp_output_format::kTabular);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

`disk_replica` command will crash due to the bug of ` multi_printer.add(std::move(disk_printer))`:
https://github.com/XiaoMi/pegasus/blob/47cea6363e963eeeb166cbd1661c5636324bb8e4/src/shell/commands/disk_rebalance.cpp#L235-L251
it can only be executed after the `disk_printer` was created, in other word, It should be move out of `for (const auto &disk_info : resp.disk_infos)` loop and in `for (const auto &err_resp : err_resps)` loop which will create new `disk_printer` every time.

Actually, It should be same with `disk_capacity` :https://github.com/XiaoMi/pegasus/blob/47cea6363e963eeeb166cbd1661c5636324bb8e4/src/shell/commands/disk_rebalance.cpp#L150-L169


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
