### PR TITLE
fix: node qps sum inconsistent with app qps sum

### DIFF
--- a/src/shell/commands.h
+++ b/src/shell/commands.h
@@ -55,6 +55,8 @@ struct list_nodes_helper
     double put_p99;
     double multi_get_p99;
     double multi_put_p99;
+    double read_cu;
+    double write_cu;
     list_nodes_helper(const std::string &n, const std::string &s)
         : node_name(n),
           node_status(s),
@@ -73,7 +75,9 @@ struct list_nodes_helper
           get_p99(0.0),
           put_p99(0.0),
           multi_get_p99(0.0),
-          multi_put_p99(0.0)
+          multi_put_p99(0.0),
+          read_cu(0.0),
+          write_cu(0.0)
     {
     }
 };

--- a/src/shell/commands/node_management.cpp
+++ b/src/shell/commands/node_management.cpp
@@ -285,7 +285,7 @@ bool ls_nodes(command_executor *e, shell_context *sc, arguments args)
                 else if (m.name.find("replica*app.pegasus*put_qps") != std::string::npos)
                     h.put_qps += m.value;
                 else if (m.name.find("replica*app.pegasus*multi_put_qps") != std::string::npos)
-                    h.put_qps += m.value;
+                    h.multi_put_qps += m.value;
                 else if (m.name.find("replica*app.pegasus*recent.read.cu") != std::string::npos)
                     h.read_cu += m.value;
                 else if (m.name.find("replica*app.pegasus*recent.write.cu") != std::string::npos)


### PR DESCRIPTION
### What problem does this PR solve?
In shell tools, we can use `app_stat -q` to show app's qps, and we also can use `nodes -q` to show nodes' qps. However, the results of two command are different. This pull request fix this bug and add cu in `nodes -q` command.

Qps counters are like `replica*app.pegasus*put_qps@1.0`, we should use `perf-counters-by-prefix` to filter app id and partition index, and accumulate them to get qps of specific node.

We record P99 and P999 latency, those counters are like `zion*profiler*RPC_RRDB_RRDB_PUT.latency.server` and `zion*profiler*RPC_RRDB_RRDB_PUT.latency.server.p999`, and latency value won't be accumulated.

As a result, I separate qps and latency in two query-commands, and display them in `nodes -q`. 

### Command example
`nodes -q` command example:
```
>>> nodes -q
[details]
address      status    get_qps  mget_qps  read_cu  put_qps  mput_qps  write_cu  get_p99(ms)  mget_p99(ms)  put_p99(ms)  mput_p99(ms)
ip1:host1    ALIVE        0.00      0.00     0.00  1014.91      0.00   3510.00         0.00          0.00       336.78          0.00
ip2:host2    ALIVE        0.00      0.00     0.00  1004.73      0.00   2675.00         0.00          0.00       344.20          0.00
ip3:host3    ALIVE        0.00      0.00     0.00   992.71      0.00   3815.00         0.00          0.00       231.92          0.00

[summary]
total_node_count    : 3
alive_node_count    : 3
unalive_node_count  : 0

```

### Check List <!--REMOVE the items that are not applicable-->
Tests
- Unit test
- Integration test
- Manual test
