### PR TITLE
fix(collector): throughput statistics isn’t right

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -637,6 +637,20 @@ update_app_pegasus_perf_counter(row_data &row, const std::string &counter_name, 
         row.rdb_estimate_num_keys += value;
     else if (counter_name == "backup_request_qps")
         row.backup_request_qps += value;
+    else if (counter_name == "get_bytes")
+        row.get_bytes += value;
+    else if (counter_name == "multi_get_bytes")
+        row.multi_get_bytes += value;
+    else if (counter_name == "scan_bytes")
+        row.scan_bytes += value;
+    else if (counter_name == "put_bytes")
+        row.put_bytes += value;
+    else if (counter_name == "multi_put_bytes")
+        row.multi_put_bytes += value;
+    else if (counter_name == "check_and_set_bytes")
+        row.check_and_set_bytes += value;
+    else if (counter_name == "check_and_mutate_bytes")
+        row.check_and_mutate_bytes += value;
     else
         return false;
     return true;


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#505 pr should support `table level` statistics, but some necessary code which in `command_helper.h` was deleted by mistake in some commit. This pr re-add it.

### Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
  *  deploy latest code with latest pegasus server config
  *  open falcon and get the table level qps and bytes statistics
  *  calc theoretical bytes, and see whether `falcon_qps × single_request_size` ≈ `falcon_bytes`
The result as follow:
![选区_201](https://user-images.githubusercontent.com/23136769/78744441-26206780-7994-11ea-9fa6-140619d0c903.png)
**Note:** for single scan bytes is unavailable, so don‘t calc it.

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
