### PR TITLE
fix(collector): no validate the app_name after parse_app_perf_counter_name

### DIFF
--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -779,7 +779,7 @@ inline bool get_app_partition_stat(shell_context *sc,
                     update_app_pegasus_perf_counter(row, counter_name, m.value);
                 }
             } else if (parse_app_perf_counter_name(m.name, app_name, counter_name)) {
-                // if the app_name from perf-counter isn't existed(may be the app was dropped), it
+                // if the app_name from perf-counter isn't existed(maybe the app was dropped), it
                 // will be ignored.
                 if (app_name_id.find(app_name) == app_name_id.end()) {
                     continue;

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -779,6 +779,11 @@ inline bool get_app_partition_stat(shell_context *sc,
                     update_app_pegasus_perf_counter(row, counter_name, m.value);
                 }
             } else if (parse_app_perf_counter_name(m.name, app_name, counter_name)) {
+                // if the app_name from perf-counter isn't existed(may be the app was dropped), it
+                // will be ignored.
+                if (app_name_id.find(app_name) == app_name_id.end()) {
+                    continue;
+                }
                 // perf-counter value will be set into partition index 0.
                 row_data &row = rows[app_name][0];
                 row.app_id = app_name_id[app_name];


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#### Related Coredump
```
#0  get_app_partition_stat (sc=sc@entry=0x3753450, rows=...) at /home/jiashuo1/work/pegasus/src/server/../shell/command_helper.h:784
#1  0x00000000004c43ad in pegasus::server::info_collector::on_app_stat (this=0x3753420) at /home/jiashuo1/work/pegasus/src/server/info_collector.cpp:136
#2  0x00007ff0d894cf61 in operator() (this=0x38d40e4) at /home/jiashuo1/app/toolchain/output/include/c++/4.8.2/functional:2464
#3  dsn::timer_task::exec (this=0x38d4014) at /home/jiashuo1/work/pegasus/rdsn/src/core/core/task.cpp:475
#4  0x00007ff0d894e059 in dsn::task::exec_internal (this=this@entry=0x38d4014) at /home/jiashuo1/work/pegasus/rdsn/src/core/core/task.cpp:180
#5  0x00007ff0d89a4c7d in dsn::task_worker::loop (this=0x3110bb0) at /home/jiashuo1/work/pegasus/rdsn/src/core/core/task_worker.cpp:211
#6  0x00007ff0d89a4e49 in dsn::task_worker::run_internal (this=0x3110bb0) at /home/jiashuo1/work/pegasus/rdsn/src/core/core/task_worker.cpp:191
#7  0x00007ff0d530f600 in std::(anonymous namespace)::execute_native_thread_routine (__p=<optimized out>) at /home/qinzuoyan/git.xiaomi/pegasus/toolchain/objdir/../gcc-4.8.2/libstdc++-v3/src/c++11/thread.cc:84
#8  0x00007ff0d5e21dc5 in start_thread () from /lib64/libpthread.so.0
#9  0x00007ff0d4a7973d in clone () from /lib64/libc.so.6

```
#### Reason
#499 add `parse_app_perf_counter_name` to parse `perf_counter_name`, but no check whether the app_name from `perf_counter_name` is existed in `dsn::app_status::AS_AVAILABLE` type apps. for example, the app was dropped and the app_name should be ignored, otherwise the code line 783 will get error result and crash at line 784.

https://github.com/XiaoMi/pegasus/blob/1a1fc190d9eac42ce359dc356483ae06d583ab8b/src/shell/command_helper.h#L781-L785

### What is changed and how it works?
 Check if the app_name existed.


### Check List <!--REMOVE the items that are not applicable-->
Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
  *  Deploy the latest code and check if `collector `crash and generate `core dump` file after runnning for a while
  *  The result is: `collector` runs well and no `core dump` file.

Related changes

- Need to cherry-pick to the release branch
- Need to be included in the release note
