### PR TITLE
feat(metrics): Add bloom filter related metrics

### DIFF
--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -209,6 +209,9 @@ info_collector::app_stat_counters *info_collector::get_app_counters(const std::s
     INIT_COUNTER(rdb_index_and_filter_blocks_mem_usage);
     INIT_COUNTER(rdb_memtable_mem_usage);
     INIT_COUNTER(rdb_estimate_num_keys);
+    INIT_COUNTER(rdb_bf_seek_negatives_rate);
+    INIT_COUNTER(rdb_bf_point_negatives_rate);
+    INIT_COUNTER(rdb_bf_point_false_positive_rate);
     INIT_COUNTER(read_qps);
     INIT_COUNTER(write_qps);
     INIT_COUNTER(backup_request_qps);

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2493,8 +2493,7 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
 
     // Update _pfc_rdb_estimate_num_keys
     // NOTE: for the same n kv pairs, kEstimateNumKeys will be counted n times, you need compaction
-    // to
-    // remove duplicate
+    // to remove duplicate
     if (_db->GetProperty(_data_cf, rocksdb::DB::Properties::kEstimateNumKeys, &str_val) &&
         dsn::buf2uint64(str_val, val)) {
         _pfc_rdb_estimate_num_keys->set(val);

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -433,16 +433,20 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
         "statistics the estimated number of keys inside the rocksdb");
 
     snprintf(name, 255, "rdb.bf_seek_negatives@%s", str_gpid.c_str());
-    _pfc_rdb_bf_seek_negatives.init_app_counter(
-        "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistics the number of times bloom filter was "
-                                                  "checked before creating iterator on a file and "
-                                                  "useful in avoiding iterator creation (and thus "
-                                                  "likely IOPs)");
+    _pfc_rdb_bf_seek_negatives.init_app_counter("app.pegasus",
+                                                name,
+                                                COUNTER_TYPE_NUMBER,
+                                                "statistics the number of times bloom filter was "
+                                                "checked before creating iterator on a file and "
+                                                "useful in avoiding iterator creation (and thus "
+                                                "likely IOPs)");
 
     snprintf(name, 255, "rdb.bf_seek_total@%s", str_gpid.c_str());
-    _pfc_rdb_bf_seek_total.init_app_counter(
-        "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistics the number of times bloom filter was "
-                                                  "checked before creating iterator on a file");
+    _pfc_rdb_bf_seek_total.init_app_counter("app.pegasus",
+                                            name,
+                                            COUNTER_TYPE_NUMBER,
+                                            "statistics the number of times bloom filter was "
+                                            "checked before creating iterator on a file");
 
     snprintf(name, 255, "rdb.bf_point_positive_true@%s", str_gpid.c_str());
     _pfc_rdb_bf_point_positive_true.init_app_counter(
@@ -459,10 +463,12 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
         "statistics the number of times bloom FullFilter has not avoided the reads");
 
     snprintf(name, 255, "rdb.bf_point_negatives@%s", str_gpid.c_str());
-    _pfc_rdb_bf_point_negatives.init_app_counter(
-        "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistics the number of times bloom FullFilter "
-                                                  "has not avoided the reads and data actually "
-                                                  "exist");
+    _pfc_rdb_bf_point_negatives.init_app_counter("app.pegasus",
+                                                 name,
+                                                 COUNTER_TYPE_NUMBER,
+                                                 "statistics the number of times bloom FullFilter "
+                                                 "has not avoided the reads and data actually "
+                                                 "exist");
 }
 
 void pegasus_server_impl::parse_checkpoints()

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -431,6 +431,38 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
         name,
         COUNTER_TYPE_NUMBER,
         "statistics the estimated number of keys inside the rocksdb");
+
+    snprintf(name, 255, "rdb.bf_seek_negatives@%s", str_gpid.c_str());
+    _pfc_rdb_bf_seek_negatives.init_app_counter(
+        "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistics the number of times bloom filter was "
+                                                  "checked before creating iterator on a file and "
+                                                  "useful in avoiding iterator creation (and thus "
+                                                  "likely IOPs)");
+
+    snprintf(name, 255, "rdb.bf_seek_total@%s", str_gpid.c_str());
+    _pfc_rdb_bf_seek_total.init_app_counter(
+        "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistics the number of times bloom filter was "
+                                                  "checked before creating iterator on a file");
+
+    snprintf(name, 255, "rdb.bf_point_positive_true@%s", str_gpid.c_str());
+    _pfc_rdb_bf_point_positive_true.init_app_counter(
+        "app.pegasus",
+        name,
+        COUNTER_TYPE_NUMBER,
+        "statistics the number of times bloom filter has avoided file reads, i.e., negatives");
+
+    snprintf(name, 255, "rdb.bf_point_positive_total@%s", str_gpid.c_str());
+    _pfc_rdb_bf_point_positive_total.init_app_counter(
+        "app.pegasus",
+        name,
+        COUNTER_TYPE_NUMBER,
+        "statistics the number of times bloom FullFilter has not avoided the reads");
+
+    snprintf(name, 255, "rdb.bf_point_negatives@%s", str_gpid.c_str());
+    _pfc_rdb_bf_point_negatives.init_app_counter(
+        "app.pegasus", name, COUNTER_TYPE_NUMBER, "statistics the number of times bloom FullFilter "
+                                                  "has not avoided the reads and data actually "
+                                                  "exist");
 }
 
 void pegasus_server_impl::parse_checkpoints()
@@ -2408,6 +2440,8 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
 {
     std::string str_val;
     uint64_t val = 0;
+
+    // Update _pfc_rdb_sst_count
     for (int i = 0; i < _data_cf_opts.num_levels; ++i) {
         int cur_level_count = 0;
         if (_db->GetProperty(rocksdb::DB::Properties::kNumFilesAtLevelPrefix + std::to_string(i),
@@ -2419,6 +2453,7 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
     _pfc_rdb_sst_count->set(val);
     dinfo_replica("_pfc_rdb_sst_count: {}", val);
 
+    // Update _pfc_rdb_sst_size
     if (_db->GetProperty(_data_cf, rocksdb::DB::Properties::kTotalSstFilesSize, &str_val) &&
         dsn::buf2uint64(str_val, val)) {
         static uint64_t bytes_per_mb = 1U << 20U;
@@ -2426,6 +2461,7 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
         dinfo_replica("_pfc_rdb_sst_size: {} bytes", val);
     }
 
+    // Update _pfc_rdb_block_cache_hit_count and _pfc_rdb_block_cache_total_count
     uint64_t block_cache_hit = _statistics->getTickerCount(rocksdb::BLOCK_CACHE_HIT);
     _pfc_rdb_block_cache_hit_count->set(block_cache_hit);
     dinfo_replica("_pfc_rdb_block_cache_hit_count: {}", block_cache_hit);
@@ -2435,29 +2471,61 @@ void pegasus_server_impl::update_replica_rocksdb_statistics()
     _pfc_rdb_block_cache_total_count->set(block_cache_total);
     dinfo_replica("_pfc_rdb_block_cache_total_count: {}", block_cache_total);
 
+    // Update _pfc_rdb_index_and_filter_blocks_mem_usage
     if (_db->GetProperty(_data_cf, rocksdb::DB::Properties::kEstimateTableReadersMem, &str_val) &&
         dsn::buf2uint64(str_val, val)) {
         _pfc_rdb_index_and_filter_blocks_mem_usage->set(val);
         dinfo_replica("_pfc_rdb_index_and_filter_blocks_mem_usage: {} bytes", val);
     }
 
+    // Update _pfc_rdb_memtable_mem_usage
     if (_db->GetProperty(_data_cf, rocksdb::DB::Properties::kCurSizeAllMemTables, &str_val) &&
         dsn::buf2uint64(str_val, val)) {
         _pfc_rdb_memtable_mem_usage->set(val);
         dinfo_replica("_pfc_rdb_memtable_mem_usage: {} bytes", val);
     }
 
-    // for the same n kv pairs, kEstimateNumKeys will be counted n times, you need compaction to
+    // Update _pfc_rdb_estimate_num_keys
+    // NOTE: for the same n kv pairs, kEstimateNumKeys will be counted n times, you need compaction
+    // to
     // remove duplicate
     if (_db->GetProperty(_data_cf, rocksdb::DB::Properties::kEstimateNumKeys, &str_val) &&
         dsn::buf2uint64(str_val, val)) {
         _pfc_rdb_estimate_num_keys->set(val);
         dinfo_replica("_pfc_rdb_estimate_num_keys: {}", val);
     }
+
+    // Update _pfc_rdb_bf_seek_negatives
+    uint64_t bf_seek_negatives = _statistics->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_USEFUL);
+    _pfc_rdb_bf_seek_negatives->set(bf_seek_negatives);
+    dinfo_replica("_pfc_rdb_bf_seek_negatives: {}", bf_seek_negatives);
+
+    // Update _pfc_rdb_bf_seek_total
+    uint64_t bf_seek_total = _statistics->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_CHECKED);
+    _pfc_rdb_bf_seek_total->set(bf_seek_total);
+    dinfo_replica("_pfc_rdb_bf_seek_total: {}", bf_seek_total);
+
+    // Update _pfc_rdb_bf_point_positive_true
+    uint64_t bf_point_positive_true =
+        _statistics->getTickerCount(rocksdb::BLOOM_FILTER_FULL_TRUE_POSITIVE);
+    _pfc_rdb_bf_point_positive_true->set(bf_point_positive_true);
+    dinfo_replica("_pfc_rdb_bf_point_positive_true: {}", bf_point_positive_true);
+
+    // Update _pfc_rdb_bf_point_positive_total
+    uint64_t bf_point_positive_total =
+        _statistics->getTickerCount(rocksdb::BLOOM_FILTER_FULL_POSITIVE);
+    _pfc_rdb_bf_point_positive_total->set(bf_point_positive_total);
+    dinfo_replica("_pfc_rdb_bf_point_positive_total: {}", bf_point_positive_total);
+
+    // Update _pfc_rdb_bf_point_negatives
+    uint64_t bf_point_negatives = _statistics->getTickerCount(rocksdb::BLOOM_FILTER_USEFUL);
+    _pfc_rdb_bf_point_negatives->set(bf_point_negatives);
+    dinfo_replica("_pfc_rdb_bf_point_negatives: {}", bf_point_negatives);
 }
 
 void pegasus_server_impl::update_server_rocksdb_statistics()
 {
+    // Update _pfc_rdb_block_cache_mem_usage
     if (_s_block_cache) {
         uint64_t val = _s_block_cache->GetUsage();
         _pfc_rdb_block_cache_mem_usage->set(val);

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -389,6 +389,11 @@ private:
     ::dsn::perf_counter_wrapper _pfc_rdb_index_and_filter_blocks_mem_usage;
     ::dsn::perf_counter_wrapper _pfc_rdb_memtable_mem_usage;
     ::dsn::perf_counter_wrapper _pfc_rdb_estimate_num_keys;
+    ::dsn::perf_counter_wrapper _pfc_rdb_bf_seek_negatives;
+    ::dsn::perf_counter_wrapper _pfc_rdb_bf_seek_total;
+    ::dsn::perf_counter_wrapper _pfc_rdb_bf_point_positive_true;
+    ::dsn::perf_counter_wrapper _pfc_rdb_bf_point_positive_total;
+    ::dsn::perf_counter_wrapper _pfc_rdb_bf_point_negatives;
 };
 
 } // namespace server

--- a/src/server/table_stats.h
+++ b/src/server/table_stats.h
@@ -56,6 +56,11 @@ struct table_stats
         total_rdb_index_and_filter_blocks_mem_usage += row.rdb_index_and_filter_blocks_mem_usage;
         total_rdb_memtable_mem_usage += row.rdb_memtable_mem_usage;
         total_rdb_estimate_num_keys += row.rdb_estimate_num_keys;
+        total_rdb_bf_seek_negatives += row.rdb_bf_seek_negatives;
+        total_rdb_bf_seek_total += row.rdb_bf_seek_total;
+        total_rdb_bf_point_positive_true += row.rdb_bf_point_positive_true;
+        total_rdb_bf_point_positive_total += row.rdb_bf_point_positive_total;
+        total_rdb_bf_point_negatives += row.rdb_bf_point_negatives;
         total_backup_request_qps += row.backup_request_qps;
         total_get_bytes += row.get_bytes;
         total_multi_get_bytes += row.multi_get_bytes;
@@ -95,6 +100,11 @@ struct table_stats
             row_stats.total_rdb_index_and_filter_blocks_mem_usage;
         total_rdb_memtable_mem_usage += row_stats.total_rdb_memtable_mem_usage;
         total_rdb_estimate_num_keys += row_stats.total_rdb_estimate_num_keys;
+        total_rdb_bf_seek_negatives += row_stats.total_rdb_bf_seek_negatives;
+        total_rdb_bf_seek_total += row_stats.total_rdb_bf_seek_total;
+        total_rdb_bf_point_positive_true += row_stats.total_rdb_bf_point_positive_true;
+        total_rdb_bf_point_positive_total += row_stats.total_rdb_bf_point_positive_total;
+        total_rdb_bf_point_negatives += row_stats.total_rdb_bf_point_negatives;
         total_backup_request_qps += row_stats.total_backup_request_qps;
         total_get_bytes += row_stats.total_get_bytes;
         total_multi_get_bytes += row_stats.total_multi_get_bytes;
@@ -130,6 +140,11 @@ struct table_stats
     double total_rdb_index_and_filter_blocks_mem_usage = 0;
     double total_rdb_memtable_mem_usage = 0;
     double total_rdb_estimate_num_keys = 0;
+    double total_rdb_bf_seek_negatives = 0;
+    double total_rdb_bf_seek_total = 0;
+    double total_rdb_bf_point_positive_true = 0;
+    double total_rdb_bf_point_positive_total = 0;
+    double total_rdb_bf_point_negatives = 0;
     double total_backup_request_qps = 0;
     double total_get_bytes = 0;
     double total_multi_get_bytes = 0;

--- a/src/shell/command_helper.h
+++ b/src/shell/command_helper.h
@@ -574,6 +574,11 @@ struct row_data
     double rdb_index_and_filter_blocks_mem_usage = 0;
     double rdb_memtable_mem_usage = 0;
     double rdb_estimate_num_keys = 0;
+    double rdb_bf_seek_negatives = 0;
+    double rdb_bf_seek_total = 0;
+    double rdb_bf_point_positive_true = 0;
+    double rdb_bf_point_positive_total = 0;
+    double rdb_bf_point_negatives = 0;
     double backup_request_qps = 0;
     double get_bytes = 0;
     double multi_get_bytes = 0;
@@ -635,6 +640,16 @@ update_app_pegasus_perf_counter(row_data &row, const std::string &counter_name, 
         row.rdb_memtable_mem_usage += value;
     else if (counter_name == "rdb.estimate_num_keys")
         row.rdb_estimate_num_keys += value;
+    else if (counter_name == "rdb.bf_seek_negatives")
+        row.rdb_bf_seek_negatives += value;
+    else if (counter_name == "rdb.bf_seek_total")
+        row.rdb_bf_seek_total += value;
+    else if (counter_name == "rdb.bf_point_positive_true")
+        row.rdb_bf_point_positive_true += value;
+    else if (counter_name == "rdb.bf_point_positive_total")
+        row.rdb_bf_point_positive_total += value;
+    else if (counter_name == "rdb.bf_point_negatives")
+        row.rdb_bf_point_negatives += value;
     else if (counter_name == "backup_request_qps")
         row.backup_request_qps += value;
     else if (counter_name == "get_bytes")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Ref https://github.com/XiaoMi/pegasus/issues/496
- Support to monitor more rocksdb metrics to observe how the storage system works
- Provide a way to optimize rocksdb configurations and user workload

### New metrics

- `replica*app.pegasus*rdb.bf_seek_total@<gpid>`

Aka `rocksdb::Tickers::BLOOM_FILTER_PREFIX_CHECKED`. Number of times bloom was checked before creating iterator on a file.

- `replica*app.pegasus*rdb.bf_seek_negatives<gpid>`

Aka `rocksdb::Tickers::BLOOM_FILTER_PREFIX_USEFUL`.  The number of times the check was useful in avoiding iterator creation (and thus likely IOPs).

- `replica*app.pegasus*rdb.bf_point_positive_true<gpid>`

Aka `rocksdb::Tickers::BLOOM_FILTER_FULL_TRUE_POSITIVE`. Of times bloom FullFilter has not avoided the reads and data actually exist.

- `replica*app.pegasus*rdb.bf_point_positive_total<gpid>`

Aka `rocksdb::Tickers::BLOOM_FILTER_FULL_POSITIVE`. Of times bloom FullFilter has not avoided the reads.

- `replica*app.pegasus*rdb.bf_point_negatives<gpid>`

Aka `rocksdb::Tickers::BLOOM_FILTER_USEFUL`. Of times bloom filter has avoided file reads, i.e., negatives.

- `collector*app.pegasus*app.stat.rdb_bf_seek_negatives_rate#<app_name>`

Rate of avoided iterator creations (and thus likely IOPs) after checking **prefix** bloom filter.

value = SUM(bf_seek_negatives) / SUM(bf_seek_total)

- `collector*app.pegasus*app.stat.rdb_bf_point_negatives_rate#<app_name>`

Rate of avoided point lookups after checking **full key** bloom filter.

value = SUM(bf_point_negatives) / (SUM(bf_point_negatives) + SUM(point_positive_total))

- `collector*app.pegasus*app.stat.rdb_bf_point_false_positive_rate#<app_name>`

False positive rate of checking **full key** bloom filter.

value = (SUM(bf_point_positive_total) - SUM(bf_point_positive_true)) / (SUM(bf_point_positive_total) - SUM(bf_point_positive_true) + SUM(bf_point_negatives))

The naming of the above metrics are according to rocksdb document about bloom filter:

![image](https://user-images.githubusercontent.com/6970676/80205863-f5ac1f00-865d-11ea-952b-252ed7aa0150.png)

### What is changed and how it works?
- Add 3 columns (`seek_n_rate`, `point_n_rate`,  `point_fp_rate`) in shell command `app_stat`

table level:
```
>>> app_stat
[app_stat]
app_name     app_id  pcount   GET  MGET   PUT  MPUT   DEL  MDEL  INCR   CAS   CAM  SCAN   RCU   WCU  expire  filter  abnormal  delay  reject  file_mb  file_num  mem_tbl_mb  mem_idx_mb  hit_rate  seek_n_rate  point_n_rate  point_fp_rate
temp             10      16  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00      0.00   0.00    0.00     0.00        16      108.18        0.03      0.99         0.50          0.99           0.01
(total:1)         0      16  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00      0.00   0.00    0.00     0.00        16      108.18        0.03      0.99         0.50          0.99           0.01
```
partition level:
```
>>> app_stat -a temp
[app_stat]
pidx           GET  MGET    PUT  MPUT   DEL  MDEL  INCR   CAS   CAM  SCAN   RCU     WCU  expire  filter  abnormal  delay  reject  file_mb  file_num  mem_tbl_mb  mem_idx_mb  hit_rate  seek_n_rate  point_n_rate  point_fp_rate
0             0.00  0.00   5.98  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00   60.00    0.00    0.00      0.00   0.00    0.00     0.00         1        6.62        0.00      0.99         0.49          0.99           0.01
1             0.00  0.00   0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00    0.00      0.00   0.00    0.00     0.00         1        5.54        0.00      0.99         0.50          0.99           0.01
2             0.00  0.00  24.03  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  241.00    0.00    0.00      0.00   0.00    0.00     0.00         1        7.48        0.00      0.99         0.49          0.99           0.01
3             0.00  0.00   0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00    0.00      0.00   0.00    0.00     0.00         1        6.45        0.00      0.99         0.50          0.99           0.01
4             0.00  0.00   0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00    0.00      0.00   0.00    0.00     0.00         1        7.49        0.00      0.99         0.50          0.99           0.01
5             0.00  0.00   4.68  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00   47.00    0.00    0.00      0.00   0.00    0.00     0.00         1        7.78        0.00      0.99         0.49          0.99           0.01
6             0.00  0.00   0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00    0.00      0.00   0.00    0.00     0.00         1        6.39        0.00      0.99         0.50          0.99           0.01
7             0.00  0.00  22.04  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  221.00    0.00    0.00      0.00   0.00    0.00     0.00         1        6.18        0.00      0.99         0.50          0.99           0.01
8             0.00  0.00   0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00    0.00      0.00   0.00    0.00     0.00         1        5.70        0.00      0.99         0.50          0.99           0.01
9             0.00  0.00   0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00    0.00      0.00   0.00    0.00     0.00         1        5.61        0.00      0.99         0.49          0.99           0.01
10            0.00  0.00   3.78  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00   38.00    0.00    0.00      0.00   0.00    0.00     0.00         1        6.35        0.00      0.99         0.50          0.99           0.01
11            0.00  0.00   0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00    0.00      0.00   0.00    0.00     0.00         1        8.06        0.00      0.99         0.49          0.99           0.01
12            0.00  0.00  22.23  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  223.00    0.00    0.00      0.00   0.00    0.00     0.00         1        7.69        0.00      0.99         0.50          0.99           0.01
13            0.00  0.00   0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00    0.00      0.00   0.00    0.00     0.00         1        5.46        0.00      0.99         0.50          0.99           0.01
14            0.00  0.00   0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00    0.00    0.00    0.00      0.00   0.00    0.00     0.00         1        6.81        0.00      0.99         0.49          0.99           0.01
15            0.00  0.00   5.28  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00   53.00    0.00    0.00      0.00   0.00    0.00     0.00         1        7.95        0.00      0.99         0.49          0.99           0.01
(total:16)    0.00  0.00  88.02  0.00  0.00  0.00  0.00  0.00  0.00  0.00  0.00  883.00    0.00    0.00      0.00   0.00    0.00     0.00        16      107.56        0.03      0.99         0.50          0.99           0.01
```

- Add 3 metrics (`rdb_bf_point_false_positive_rate `, `rdb_bf_point_negatives_rate `, `rdb_bf_seek_negatives_rate `) to app level entity
![image](https://user-images.githubusercontent.com/10775040/80088336-f45ff100-858e-11ea-811b-a53a2985e14d.png)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
```
#!/usr/bin/env python
# coding:utf-8

from pypegasus.pgclient import *

from twisted.internet import reactor
from twisted.internet.defer import inlineCallbacks, Deferred


@inlineCallbacks
def basic_test():
    # init
    c = Pegasus(['meta1:port', 'meta2:port'], 'temp')

    suc = yield c.init()
    if not suc:
        reactor.stop()
        print('ERROR: connect pegasus server failed')
        return

    kCount = 10000
    # write test data set A
    print("start to set")
    for i in range(kCount):
        (ret, ign) = yield c.set('hkey_' + str(i), 'skey', 'value_' + str(i), 0, 500)
        #if ret == error_types.ERR_OK.value: continue
        #print('set hkey_' + str(i) + ' : skey => value_' + str(i) + ' ' + str(ret))

    # get test data set A and B, B has the same size of A
    print("start to get")
    for i in range(2*kCount):
        (ret, v) = yield c.get('hkey_' + str(i), 'skey')
        #if ret != error_types.ERR_OK.value:
        #    print('hkey_' + str(i) + ' : skey => ' + v)

    # scan test data set A and B, B has the same size of A. we can get 'seek_n_rate' in shell and 'rdb_bf_seek_negatives_rate' in metric around value of 0.5
    print("start to scan")
    o = ScanOptions()
    o.batch_size = 1
    for i in range(2*kCount):
        s = c.get_scanner('hkey_' + str(i), '6', '8', o)
        while True:
            try:
                ret = yield s.get_next()
                #print('get_next ret: ', ret)
            except Exception as e:
                print(e)
                break

            if not ret:
                break
        s.close()

    reactor.stop()


if __name__ == "__main__":
    reactor.callWhenRunning(basic_test)
    reactor.run()
```

Related changes

- Need to cherry-pick to the release branch
Yes
- Need to update the documentation
Yes
- Need to be included in the release note
Yes