### PR TITLE
feat(rocksdb): Support more configurable items for bloom filter

### DIFF
--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -279,6 +279,18 @@
   rocksdb_disable_bloom_filter = false
   # Bloom filter type, should be either 'common' or 'prefix'
   rocksdb_filter_type = prefix
+  # rocksdb_bloom_filter_bits_per_key |           false positive rate
+  #                                   | rocksdb_format_version < 5 | rocksdb_format_version = 5
+  #        6                                 5.70953                      5.69888
+  #        8                                 2.45766                      2.29709
+  #       10                                 1.13977                      0.959254
+  #       12                                 0.662498                     0.411593
+  #       16                                 0.353023                     0.0873754
+  #       24                                 0.261552                     0.0060971
+  #       50                                 0.225453                     ~0.00003
+  rocksdb_bloom_filter_bits_per_key = 10
+  # SST file format version, should be either 2 or 5
+  rocksdb_format_version = 2
 
   # 3000, 30MB, 1000, 30s
   rocksdb_multi_get_max_iteration_count = 3000

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -290,6 +290,11 @@
   #       50                                 0.225453                     ~0.00003
   rocksdb_bloom_filter_bits_per_key = 10
   # SST file format version, should be either 2 or 5
+  # COMPATIBILITY ATTENTION:
+  # Although old releases would see the new structure as corrupt filter data and read the
+  # table as if there's no filter, we've decided only to enable the new Bloom filter with new
+  # format_version=5. This provides a smooth path for automatic adoption over time, with an
+  # option for early opt-in.
   rocksdb_format_version = 2
 
   # 3000, 30MB, 1000, 30s

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -293,7 +293,40 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     bool disable_bloom_filter = dsn_config_get_value_bool(
         "pegasus.server", "rocksdb_disable_bloom_filter", false, "Whether to disable bloom filter");
     if (!disable_bloom_filter) {
-        tbl_opts.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
+        // average bits allocated per key in bloom filter.
+        // bits_per_key    |           false positive rate
+        //                 | format_version < 5 | format_version = 5
+        //       6                5.70953              5.69888
+        //       8                2.45766              2.29709
+        //      10                1.13977              0.959254
+        //      12                0.662498             0.411593
+        //      16                0.353023             0.0873754
+        //      24                0.261552             0.0060971
+        //      50                0.225453             ~0.00003
+        // Recommend using no more than three decimal digits after the decimal point, as in 6.667.
+        // More details: https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter
+        double bits_per_key =
+            dsn_config_get_value_double("pegasus.server",
+                                        "rocksdb_bloom_filter_bits_per_key",
+                                        10,
+                                        "average bits allocated per key in bloom filter");
+        // COMPATIBILITY ATTENTION:
+        // Although old releases would see the new structure as corrupt filter data and read the
+        // table as if there's no filter, we've decided only to enable the new Bloom filter with new
+        // format_version=5. This provides a smooth path for automatic adoption over time, with an
+        // option for early opt-in.
+        // Reference from rocksdb commit:
+        // https://github.com/facebook/rocksdb/commit/f059c7d9b96300091e07429a60f4ad55dac84859
+        int format_version = (int)dsn_config_get_value_int64(
+            "pegasus.server", "rocksdb_format_version", 2, "block based table data format version, "
+                                                           "only 2 and 5 is supported in Pegasus. "
+                                                           "2 is the old version, 5 is the new "
+                                                           "version supported since rocksdb "
+                                                           "v6.6.4");
+        dassert(format_version == 2 || format_version == 5,
+                "[pegasus.server]rocksdb_format_version should be either '2' or '5'.");
+        tbl_opts.format_version = format_version;
+        tbl_opts.filter_policy.reset(rocksdb::NewBloomFilterPolicy(bits_per_key, false));
 
         std::string filter_type =
             dsn_config_get_value_string("pegasus.server",

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -317,12 +317,15 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
         // option for early opt-in.
         // Reference from rocksdb commit:
         // https://github.com/facebook/rocksdb/commit/f059c7d9b96300091e07429a60f4ad55dac84859
-        int format_version = (int)dsn_config_get_value_int64(
-            "pegasus.server", "rocksdb_format_version", 2, "block based table data format version, "
-                                                           "only 2 and 5 is supported in Pegasus. "
-                                                           "2 is the old version, 5 is the new "
-                                                           "version supported since rocksdb "
-                                                           "v6.6.4");
+        int format_version =
+            (int)dsn_config_get_value_int64("pegasus.server",
+                                            "rocksdb_format_version",
+                                            2,
+                                            "block based table data format version, "
+                                            "only 2 and 5 is supported in Pegasus. "
+                                            "2 is the old version, 5 is the new "
+                                            "version supported since rocksdb "
+                                            "v6.6.4");
         dassert(format_version == 2 || format_version == 5,
                 "[pegasus.server]rocksdb_format_version should be either '2' or '5'.");
         tbl_opts.format_version = format_version;

--- a/src/shell/commands/table_management.cpp
+++ b/src/shell/commands/table_management.cpp
@@ -516,7 +516,7 @@ bool app_stat(command_executor *e, shell_context *sc, arguments args)
     }
     std::ostream out(buf);
 
-    ::dsn::utils::table_printer tp("app_stat");
+    ::dsn::utils::table_printer tp("app_stat", 2 /* tabular_width */, 3 /* precision */);
     tp.add_title(app_name.empty() ? "app_name" : "pidx");
     if (app_name.empty()) {
         tp.add_column("app_id", tp_alignment::kRight);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
- Support to config `bits_per_key` for Bloom filter to provide lower false positive rate
- Support to config `format_version` for SST to provide a faster and more accurate Bloom filter  implementation

### What is changed and how it works?
Add config in replica server's config.ini:
```
[pegasus.server]
rocksdb_bloom_filter_bits_per_key = 10
rocksdb_format_version = 2
```

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
1. Write test data set A
2. Read test data set B, whose hashkey scale size is 100 times larger than test data set A.
    So 99% of these items are not exist, but these point lookups will consult Bloom filters, then negative or positive will be returned by Bloom filters to indicate whether the key is definity not exist or may exist.
3. Oberve `point_fp_rate` in shell command `app_stat`

#### Result
- When `rocksdb_bloom_filter_bits_per_key = 10` and `rocksdb_format_version = 2`
```
>>> app_stat -a test
[app_stat]
pidx          GET  MGET   PUT  ...  point_n_rate  point_fp_rate
0            0.00  0.00  0.00  ...      0.960577       0.011309
1            0.00  0.00  0.00  ...      0.960897       0.010979
2            0.00  0.00  0.00  ...      0.961837       0.009758
3            0.00  0.00  0.00  ...      0.961982       0.009609
4            0.00  0.00  0.00  ...      0.960831       0.010793
5            0.00  0.00  0.00  ...      0.961616       0.009985
6            0.00  0.00  0.00  ...      0.961044       0.010783
7            0.00  0.00  0.00  ...      0.959726       0.012140
(total:8)    0.00  0.00  0.00  ...      0.961064       0.010670
```
- When `rocksdb_bloom_filter_bits_per_key = 24` and `rocksdb_format_version = 2`
```
>>> app_stat -a test_v2_b24
[app_stat]
pidx          GET  MGET   PUT  ...  point_n_rate  point_fp_rate
0            0.00  0.00  0.00  ...      0.997455       0.002545
1            0.00  0.00  0.00  ...      0.997706       0.002294
2            0.00  0.00  0.00  ...      0.997608       0.002392
3            0.00  0.00  0.00  ...      0.997616       0.002384
4            0.00  0.00  0.00  ...      0.997608       0.002392
5            0.00  0.00  0.00  ...      0.997591       0.002409
6            0.00  0.00  0.00  ...      0.997116       0.002884
7            0.00  0.00  0.00  ...      0.997156       0.002844
(total:8)    0.00  0.00  0.00  ...      0.997482       0.002518
```
- When `rocksdb_bloom_filter_bits_per_key = 24` and `rocksdb_format_version = 5`
```
>>> app_stat -a test_v5_b24
[app_stat]
pidx          GET  MGET   PUT  ...  point_n_rate  point_fp_rate
0            0.00  0.00  0.00  ...      0.999933       0.000067
1            0.00  0.00  0.00  ...      0.999944       0.000056
2            0.00  0.00  0.00  ...      0.999965       0.000035
3            0.00  0.00  0.00  ...      0.999920       0.000080
4            0.00  0.00  0.00  ...      0.999944       0.000056
5            0.00  0.00  0.00  ...      0.999955       0.000045
6            0.00  0.00  0.00  ...      0.999944       0.000056
7            0.00  0.00  0.00  ...      0.999965       0.000035
(total:8)    0.00  0.00  0.00  ...      0.999946       0.000054
```

Code changes

- Has exported function/method change
No
- Has exported variable/fields change
No
- Has interface methods change
No
- Has persistent data change
Yes

Side effects

- Possible performance regression
No
- Increased code complexity
No
- Breaking backward compatibility
1. New version of Pegasus can read bloom filter normally when `rocksdb_format_version` is `2` or `5`
2. Old version of Pegasus can **ONLY** read bloom filter normally when `rocksdb_format_version` is `2`
3. Old version of Pegasus would see the new structure as **corrupt** filter data and read the table as if there's **no filter**

Related changes

- Need to cherry-pick to the release branch
Yes
- Need to update the documentation
Yes
- Need to be included in the release note
Yes