### PR TITLE
fix: bind prometheus exposer to 0.0.0.0

### DIFF
--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -106,6 +106,17 @@ copy_file `get_system_lib server aio` ${pack}/bin/`get_system_libname server aio
 copy_file `get_system_lib server zstd` ${pack}/bin/`get_system_libname server zstd`
 copy_file `get_system_lib server lz4` ${pack}/bin/`get_system_libname server lz4`
 
+DISTRIB_ID=$(cat /etc/*-release | grep DISTRIB_ID | awk -F'=' '{print $2}')
+DISTRIB_RELEASE=$(cat /etc/*-release | grep DISTRIB_RELEASE | awk -F'=' '{print $2}')
+if [ -n "$DISTRIB_ID" ] && [ -n "$DISTRIB_RELEASE" ]; then
+  if [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$DISTRIB_RELEASE" == "18.04" ]; then
+    copy_file "$(get_system_lib server icui18n)" "$pack/bin/$(get_system_libname server icui18n)"
+    copy_file "$(get_system_lib server icuuc)" "$pack/bin/$(get_system_libname server icuuc)"
+    copy_file "$(get_system_lib server icudata)" "$pack/bin/$(get_system_libname server icudata)"
+  fi
+  # more cases can be added here.
+fi
+
 chmod +x ${pack}/bin/pegasus_* ${pack}/bin/*.sh
 chmod -x ${pack}/bin/lib*
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

The prometheus exposer formerly bound to an external IP address, for example "10.231.52.xxx:9091", and served on the HTTP URL '10.231.52.xxx:9091/metrics'. But it's unable to serve on '0.0.0.0:9091' and '127.0.0.1:9091'. It is therefore inconvenient to set up an onebox environment with prometheus.

This limitation can be resolved by binding to '0.0.0.0:9091' so that '0.0.0.0:9091', '127.0.0.1:9091', '10.231.52.xxx:9091' are all accessible.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
