### PR TITLE
feat(dup): add metric for time lag between master&slave

### DIFF
--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -106,6 +106,17 @@ copy_file `get_system_lib server aio` ${pack}/bin/`get_system_libname server aio
 copy_file `get_system_lib server zstd` ${pack}/bin/`get_system_libname server zstd`
 copy_file `get_system_lib server lz4` ${pack}/bin/`get_system_libname server lz4`
 
+DISTRIB_ID=$(cat /etc/*-release | grep DISTRIB_ID | awk -F'=' '{print $2}')
+DISTRIB_RELEASE=$(cat /etc/*-release | grep DISTRIB_RELEASE | awk -F'=' '{print $2}')
+if [ -n "$DISTRIB_ID" ] && [ -n "$DISTRIB_RELEASE" ]; then
+  if [ "$DISTRIB_ID" == "Ubuntu" ] && [ "$DISTRIB_RELEASE" == "18.04" ]; then
+    copy_file "$(get_system_lib server icui18n)" "$pack/bin/$(get_system_libname server icui18n)"
+    copy_file "$(get_system_lib server icuuc)" "$pack/bin/$(get_system_libname server icuuc)"
+    copy_file "$(get_system_lib server icudata)" "$pack/bin/$(get_system_libname server icudata)"
+  fi
+  # more cases can be added here.
+fi
+
 chmod +x ${pack}/bin/pegasus_* ${pack}/bin/*.sh
 chmod -x ${pack}/bin/lib*
 

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -307,11 +307,11 @@ int pegasus_write_service::duplicate(int64_t decree,
 
     _pfc_duplicate_qps->increment();
     auto cleanup = dsn::defer([this, &request]() {
-        uint64_t latency_us = dsn_now_us() - request.timestamp;
-        if (latency_us > _dup_lagging_write_threshold_ms * 1000) {
+        uint64_t latency_ms = (dsn_now_us() - request.timestamp) / 1000;
+        if (latency_ms > _dup_lagging_write_threshold_ms) {
             _pfc_dup_lagging_writes->increment();
         }
-        _pfc_dup_time_lag->set(latency_us / 1000);
+        _pfc_dup_time_lag->set(latency_ms);
     });
     dsn::message_ex *write = dsn::from_blob_to_received_msg(request.task_code, request.raw_message);
     bool is_delete = request.task_code == dsn::apps::RPC_RRDB_RRDB_MULTI_REMOVE ||

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -14,7 +14,8 @@ namespace pegasus {
 namespace server {
 
 pegasus_write_service::pegasus_write_service(pegasus_server_impl *server)
-    : _server(server),
+    : replica_base(server),
+      _server(server),
       _impl(new impl(server)),
       _batch_start_time(0),
       _cu_calculator(server->_cu_calculator.get())
@@ -107,7 +108,7 @@ pegasus_write_service::pegasus_write_service(pegasus_server_impl *server)
 
     _pfc_dup_time_lag.init_app_counter(
         "app.pegasus",
-        fmt::format("dup.time_lag_ms@{}", str_gpid).c_str(),
+        fmt::format("dup.time_lag_ms@{}", app_name()).c_str(),
         COUNTER_TYPE_NUMBER_PERCENTILES,
         "the time (in ms) lag between master and slave in the duplication");
 }

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -308,7 +308,7 @@ int pegasus_write_service::duplicate(int64_t decree,
     _pfc_duplicate_qps->increment();
     auto cleanup = dsn::defer([this, &request]() {
         uint64_t latency_us = dsn_now_us() - request.timestamp;
-        if (latency_us > _dup_lagging_write_threshold_ms) {
+        if (latency_us > _dup_lagging_write_threshold_ms * 1000) {
             _pfc_dup_lagging_writes->increment();
         }
         _pfc_dup_time_lag->set(latency_us / 1000);

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -121,7 +121,7 @@ pegasus_write_service::pegasus_write_service(pegasus_server_impl *server)
     _pfc_dup_lagging_writes.init_app_counter(
         "app.pegasus",
         fmt::format("dup.lagging_writes@{}", app_name()).c_str(),
-        COUNTER_TYPE_NUMBER,
+        COUNTER_TYPE_VOLATILE_NUMBER,
         "the number of lagging writes (time lag larger than `dup_lagging_write_threshold_ms`)");
 }
 

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -168,6 +168,7 @@ private:
     uint64_t _batch_start_time;
 
     capacity_unit_calculator *_cu_calculator;
+    int64_t _dup_lagging_write_threshold_ms;
 
     ::dsn::perf_counter_wrapper _pfc_put_qps;
     ::dsn::perf_counter_wrapper _pfc_multi_put_qps;
@@ -178,6 +179,7 @@ private:
     ::dsn::perf_counter_wrapper _pfc_check_and_mutate_qps;
     ::dsn::perf_counter_wrapper _pfc_duplicate_qps;
     ::dsn::perf_counter_wrapper _pfc_dup_time_lag;
+    ::dsn::perf_counter_wrapper _pfc_dup_lagging_writes;
 
     ::dsn::perf_counter_wrapper _pfc_put_latency;
     ::dsn::perf_counter_wrapper _pfc_multi_put_latency;

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -85,7 +85,7 @@ class capacity_unit_calculator;
 /// As the signatures imply, this class is not responsible for replying the rpc,
 /// the caller(pegasus_server_write) should do.
 /// \see pegasus::server::pegasus_server_write::on_batched_write_requests
-class pegasus_write_service
+class pegasus_write_service : dsn::replication::replica_base
 {
 public:
     explicit pegasus_write_service(pegasus_server_impl *server);

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -177,6 +177,7 @@ private:
     ::dsn::perf_counter_wrapper _pfc_check_and_set_qps;
     ::dsn::perf_counter_wrapper _pfc_check_and_mutate_qps;
     ::dsn::perf_counter_wrapper _pfc_duplicate_qps;
+    ::dsn::perf_counter_wrapper _pfc_dup_time_lag;
 
     ::dsn::perf_counter_wrapper _pfc_put_latency;
     ::dsn::perf_counter_wrapper _pfc_multi_put_latency;

--- a/src/server/test/pegasus_mutation_duplicator_test.cpp
+++ b/src/server/test/pegasus_mutation_duplicator_test.cpp
@@ -30,7 +30,7 @@ public:
 
     void test_duplicate()
     {
-        replica_base replica(dsn::gpid(1, 1), "fake_replica");
+        replica_base replica(dsn::gpid(1, 1), "fake_replica", "temp");
         auto duplicator = new_mutation_duplicator(&replica, "onebox2", "temp");
         duplicator->set_task_environment(&_env);
 
@@ -87,7 +87,7 @@ public:
 
     void test_duplicate_failed()
     {
-        replica_base replica(dsn::gpid(1, 1), "fake_replica");
+        replica_base replica(dsn::gpid(1, 1), "fake_replica", "temp");
         auto duplicator = new_mutation_duplicator(&replica, "onebox2", "temp");
         duplicator->set_task_environment(&_env);
 
@@ -150,7 +150,7 @@ public:
 
     void test_duplicate_isolated_hashkeys()
     {
-        replica_base replica(dsn::gpid(1, 1), "fake_replica");
+        replica_base replica(dsn::gpid(1, 1), "fake_replica", "temp");
         auto duplicator = new_mutation_duplicator(&replica, "onebox2", "temp");
         duplicator->set_task_environment(&_env);
 
@@ -196,7 +196,7 @@ public:
 
     void test_create_duplicator()
     {
-        replica_base replica(dsn::gpid(1, 1), "fake_replica");
+        replica_base replica(dsn::gpid(1, 1), "fake_replica", "temp");
         auto duplicator = new_mutation_duplicator(&replica, "onebox2", "temp");
         duplicator->set_task_environment(&_env);
         auto duplicator_impl = dynamic_cast<pegasus_mutation_duplicator *>(duplicator.get());
@@ -295,7 +295,7 @@ TEST_F(pegasus_mutation_duplicator_test, create_duplicator) { test_create_duplic
 
 TEST_F(pegasus_mutation_duplicator_test, duplicate_duplicate)
 {
-    replica_base replica(dsn::gpid(1, 1), "fake_replica");
+    replica_base replica(dsn::gpid(1, 1), "fake_replica", "temp");
     auto duplicator = new_mutation_duplicator(&replica, "onebox2", "temp");
     duplicator->set_task_environment(&_env);
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

We need to know the time lag between master and slave.  So in this PR, I added two perf-counters:

### New perf-counters

- `replica*app.pegasus*dup.time_lag_ms@<app_name>`

The time lag between master and slave. A write to master will first record a timestamp (`ts1`) before running 2PC. Then when it duplicates to the slave and applies to the slave's rocksdb (`ts2`), this counter will calculate the duration between the two timestamps.

We can set an alert for this metric in order to detect failures on duplication. 

- `replica*app.pegasus*dup.lagging_writes@<app_name>`

A write with time lag larger than `dup_lagging_write_threshold_ms` is defined as a "lagging write".
This counter calculates the number of such lagging writes.

### New configuration

- [pegasus.server] dup_lagging_write_threshold_ms

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Increases the duplication workload at 11:30~11:31, the lagging number bursts. While the workload going down, the time-lag decreases to 1s.

![image](https://user-images.githubusercontent.com/6970676/80558880-6fe9f400-8a0e-11ea-9ee8-c7245c365ed7.png)

![image](https://user-images.githubusercontent.com/6970676/80558747-ffdb6e00-8a0d-11ea-83b3-53916ee35e05.png)

![image](https://user-images.githubusercontent.com/6970676/80558735-f520d900-8a0d-11ea-920d-7ab3f952ac71.png)

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
