### PR TITLE
improvement: add logging on rocksdb write stalls

### DIFF
--- a/src/server/pegasus_event_listener.h
+++ b/src/server/pegasus_event_listener.h
@@ -7,23 +7,22 @@
 #include <rocksdb/db.h>
 #include <rocksdb/listener.h>
 #include <dsn/perf_counter/perf_counter_wrapper.h>
+#include <dsn/dist/replication/replica_base.h>
 
 namespace pegasus {
 namespace server {
 
-class pegasus_event_listener : public rocksdb::EventListener
+class pegasus_event_listener : public rocksdb::EventListener, dsn::replication::replica_base
 {
 public:
-    pegasus_event_listener();
-    virtual ~pegasus_event_listener();
+    explicit pegasus_event_listener(replica_base *r);
+    ~pegasus_event_listener() override = default;
 
-    virtual void OnFlushCompleted(rocksdb::DB *db,
-                                  const rocksdb::FlushJobInfo &flush_job_info) override;
+    void OnFlushCompleted(rocksdb::DB *db, const rocksdb::FlushJobInfo &flush_job_info) override;
 
-    virtual void OnCompactionCompleted(rocksdb::DB *db,
-                                       const rocksdb::CompactionJobInfo &ci) override;
+    void OnCompactionCompleted(rocksdb::DB *db, const rocksdb::CompactionJobInfo &ci) override;
 
-    virtual void OnStallConditionsChanged(const rocksdb::WriteStallInfo &info) override;
+    void OnStallConditionsChanged(const rocksdb::WriteStallInfo &info) override;
 
 private:
     ::dsn::perf_counter_wrapper _pfc_recent_flush_completed_count;

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -122,7 +122,7 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
     _statistics->set_stats_level(rocksdb::kExceptDetailedTimers);
     _db_opts.statistics = _statistics;
 
-    _db_opts.listeners.emplace_back(new pegasus_event_listener());
+    _db_opts.listeners.emplace_back(new pegasus_event_listener(this));
 
     // flush threads are shared among all rocksdb instances in one process.
     _db_opts.max_background_flushes =


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

![image](https://user-images.githubusercontent.com/6970676/81250391-705c3d80-9053-11ea-9284-e73122455c6f.png)

Pegasus has metrics for rocksdb write-stalls, but no logging for which replica that was stalled.
So even we have been alerted for this event, we are not able to improve the situation. 

### What is changed and how it works?

I add logs for each rocksdb write stall, including delayed and stopped.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Related changes

- Need to cherry-pick to the release branch
