### PR TITLE
improvement(cu): set ttl on capacity unit data

### DIFF
--- a/src/server/result_writer.cpp
+++ b/src/server/result_writer.cpp
@@ -3,9 +3,15 @@
 // can be found in the LICENSE file in the root directory of this source tree.
 
 #include "result_writer.h"
+#include <dsn/utility/flags.h>
 
 namespace pegasus {
 namespace server {
+
+DSN_DEFINE_int32("pegasus.collector",
+                 capacity_unit_saving_ttl_days,
+                 90,
+                 "the ttl of the CU data, 0 if no ttl");
 
 DEFINE_TASK_CODE(LPC_WRITE_RESULT, TASK_PRIORITY_COMMON, ::dsn::THREAD_POOL_DEFAULT)
 
@@ -50,7 +56,12 @@ void result_writer::set_result(const std::string &hash_key,
         }
     };
 
-    _client->async_set(hash_key, sort_key, value, std::move(async_set_callback));
+    _client->async_set(hash_key,
+                       sort_key,
+                       value,
+                       std::move(async_set_callback),
+                       5000,
+                       FLAGS_capacity_unit_saving_ttl_days * 3600 * 24);
 }
 } // namespace server
 } // namespace pegasus


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

To store capacity unit data we create a table (by config `[pegasus.collector] usage_stat_app`) for each Pegasus cluster. The data is currently stored without TTL, which means no space limit on the "usage_stat_app".

### What is changed and how it works?

I add a configuration called 'capacity_unit_saving_ttl_days', each capacity unit data will expire after this period.

```diff
[pegasus.collector]
+ capacity_unit_saving_ttl_days = 90
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```
>>> use stat
OK
>>> full_scan -n 1
partition: all
hash_key_filter_type: no_filter
sort_key_filter_type: no_filter
value_filter_type: no_filter
max_count: 1
timout_ms: 5000
detailed: false
no_value: false

"2020-05-10 21:01:54" : "cu@10.232.52.147:34801" => "{\"2\":[9,9]}"

1 key-value pairs got.
>>> ttl "2020-05-10 21:01:54" "cu@10.232.52.147:34801"
7775543

app_id          : 1
partition_index : 3
server          : 10.232.52.147:34803
```

Side effects

- Breaking backward compatibility

If some users want capacity unit data never expired, they can set the config to 0. We should give a notice tip in our documentation.

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
