### PR TITLE
feat(rocksdb): Support to config meta data read source

### DIFF
--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -16,6 +16,12 @@ DSN_DEFINE_validator(meta_store_type, [](const char *meta_store_type) {
     return strcmp(meta_store_type, "manifest") == 0 || strcmp(meta_store_type, "metacf") == 0;
 });
 
+DSN_DEFINE_string("pegasus.server", get_meta_store_type, "manifest",
+    "Where to get meta data, now support 'manifest' and 'metacf'");
+DSN_DEFINE_validator(get_meta_store_type, [](const char *type) {
+    return strcmp(type, "manifest") == 0 || strcmp(type, "metacf") == 0;
+});
+
 const std::string meta_store::DATA_VERSION = "pegasus_data_version";
 const std::string meta_store::LAST_FLUSHED_DECREE = "pegasus_last_flushed_decree";
 const std::string meta_store::LAST_MANUAL_COMPACT_FINISH_TIME =
@@ -28,7 +34,7 @@ meta_store::meta_store(pegasus_server_impl *server,
 {
     // disable write ahead logging as replication handles logging instead now
     _wt_opts.disableWAL = true;
-    _get_meta_store_type = (strcmp(meta_store_type, "manifest") == 0 ? meta_store_type::kManifestOnly : meta_store_type::kMetaCFOnly);
+    _get_meta_store_type = (strcmp(FLAGS_meta_store_type, "manifest") == 0 ? meta_store_type::kManifestOnly : meta_store_type::kMetaCFOnly);
 }
 
 uint64_t meta_store::get_last_flushed_decree() const

--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -10,8 +10,10 @@
 namespace pegasus {
 namespace server {
 
-DSN_DEFINE_string("pegasus.server", get_meta_store_type, "manifest",
-    "Where to get meta data, now support 'manifest' and 'metacf'");
+DSN_DEFINE_string("pegasus.server",
+                  get_meta_store_type,
+                  "manifest",
+                  "Where to get meta data, now support 'manifest' and 'metacf'");
 DSN_DEFINE_validator(get_meta_store_type, [](const char *type) {
     return strcmp(type, "manifest") == 0 || strcmp(type, "metacf") == 0;
 });
@@ -28,7 +30,9 @@ meta_store::meta_store(pegasus_server_impl *server,
 {
     // disable write ahead logging as replication handles logging instead now
     _wt_opts.disableWAL = true;
-    _get_meta_store_type = (strcmp(FLAGS_get_meta_store_type, "manifest") == 0 ? meta_store_type::kManifestOnly : meta_store_type::kMetaCFOnly);
+    _get_meta_store_type =
+        (strcmp(FLAGS_get_meta_store_type, "manifest") == 0 ? meta_store_type::kManifestOnly
+                                                            : meta_store_type::kMetaCFOnly);
 }
 
 uint64_t meta_store::get_last_flushed_decree() const

--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -10,12 +10,6 @@
 namespace pegasus {
 namespace server {
 
-DSN_DEFINE_string("pegasus.server", meta_store_type, "manifest",
-    "Where to get meta data, now support 'manifest' and 'metacf'");
-DSN_DEFINE_validator(meta_store_type, [](const char *meta_store_type) {
-    return strcmp(meta_store_type, "manifest") == 0 || strcmp(meta_store_type, "metacf") == 0;
-});
-
 DSN_DEFINE_string("pegasus.server", get_meta_store_type, "manifest",
     "Where to get meta data, now support 'manifest' and 'metacf'");
 DSN_DEFINE_validator(get_meta_store_type, [](const char *type) {
@@ -34,7 +28,7 @@ meta_store::meta_store(pegasus_server_impl *server,
 {
     // disable write ahead logging as replication handles logging instead now
     _wt_opts.disableWAL = true;
-    _get_meta_store_type = (strcmp(FLAGS_meta_store_type, "manifest") == 0 ? meta_store_type::kManifestOnly : meta_store_type::kMetaCFOnly);
+    _get_meta_store_type = (strcmp(FLAGS_get_meta_store_type, "manifest") == 0 ? meta_store_type::kManifestOnly : meta_store_type::kMetaCFOnly);
 }
 
 uint64_t meta_store::get_last_flushed_decree() const

--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -5,9 +5,16 @@
 #include "meta_store.h"
 
 #include <dsn/dist/fmt_logging.h>
+#include <dsn/utility/flags.h>
 
 namespace pegasus {
 namespace server {
+
+DSN_DEFINE_string("pegasus.server", meta_store_type, "manifest",
+    "Where to get meta data, now support 'manifest' and 'metacf'");
+DSN_DEFINE_validator(meta_store_type, [](const char *meta_store_type) {
+    return strcmp(meta_store_type, "manifest") == 0 || strcmp(meta_store_type, "metacf") == 0;
+});
 
 const std::string meta_store::DATA_VERSION = "pegasus_data_version";
 const std::string meta_store::LAST_FLUSHED_DECREE = "pegasus_last_flushed_decree";
@@ -21,11 +28,12 @@ meta_store::meta_store(pegasus_server_impl *server,
 {
     // disable write ahead logging as replication handles logging instead now
     _wt_opts.disableWAL = true;
+    _get_meta_store_type = (strcmp(meta_store_type, "manifest") == 0 ? meta_store_type::kManifestOnly : meta_store_type::kMetaCFOnly);
 }
 
-uint64_t meta_store::get_last_flushed_decree(meta_store_type type) const
+uint64_t meta_store::get_last_flushed_decree() const
 {
-    switch (type) {
+    switch (_get_meta_store_type) {
     case meta_store_type::kManifestOnly:
         return _db->GetLastFlushedDecree();
     case meta_store_type::kMetaCFOnly: {
@@ -39,9 +47,9 @@ uint64_t meta_store::get_last_flushed_decree(meta_store_type type) const
     }
 }
 
-uint32_t meta_store::get_data_version(meta_store_type type) const
+uint32_t meta_store::get_data_version() const
 {
-    switch (type) {
+    switch (_get_meta_store_type) {
     case meta_store_type::kManifestOnly:
         return _db->GetPegasusDataVersion();
     case meta_store_type::kMetaCFOnly: {
@@ -55,9 +63,9 @@ uint32_t meta_store::get_data_version(meta_store_type type) const
     }
 }
 
-uint64_t meta_store::get_last_manual_compact_finish_time(meta_store_type type) const
+uint64_t meta_store::get_last_manual_compact_finish_time() const
 {
-    switch (type) {
+    switch (_get_meta_store_type) {
     case meta_store_type::kManifestOnly:
         return _db->GetLastManualCompactFinishTime();
     case meta_store_type::kMetaCFOnly: {

--- a/src/server/meta_store.h
+++ b/src/server/meta_store.h
@@ -32,9 +32,9 @@ public:
 
     meta_store(pegasus_server_impl *server, rocksdb::DB *db, rocksdb::ColumnFamilyHandle *meta_cf);
 
-    uint64_t get_last_flushed_decree(meta_store_type type) const;
-    uint32_t get_data_version(meta_store_type type) const;
-    uint64_t get_last_manual_compact_finish_time(meta_store_type type) const;
+    uint64_t get_last_flushed_decree() const;
+    uint32_t get_data_version() const;
+    uint64_t get_last_manual_compact_finish_time() const;
 
     void set_last_flushed_decree(uint64_t decree) const;
     void set_data_version(uint32_t version) const;
@@ -55,6 +55,8 @@ private:
     rocksdb::DB *_db;
     rocksdb::ColumnFamilyHandle *_meta_cf;
     rocksdb::WriteOptions _wt_opts;
+
+    meta_store_type _get_meta_store_type;
 };
 
 } // namespace server


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
After https://github.com/XiaoMi/pegasus/pull/494, we have written meta info into both manifest and meta CF, and meta info is read from manifest all the same, if we want to read from meta CF, we have to modify code and pack a new release version.
This patch make meta info read source into config file, it's more convenient for testing and transit to use original rocksdb.

### What is changed and how it works?
No functional changes.