### PR TITLE
fix: fix bug in table_hotspot_policy

### DIFF
--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -306,7 +306,7 @@ void info_collector::on_storage_size_stat(int remaining_retry_count)
 hotspot_calculator *info_collector::get_hotspot_calculator(const std::string &app_name,
                                                            const int partition_num)
 {
-    std::string app_name_count = app_name + std::string(partition_num);
+    std::string app_name_count = app_name + std::to_string(partition_num);
     auto iter = _hotspot_calculator_store.find(app_name_count);
     if (iter != _hotspot_calculator_store.end()) {
         return iter->second;

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -307,7 +307,7 @@ hotspot_calculator *info_collector::get_hotspot_calculator(const std::string &ap
 {
     // use appname+partition_num as a key can prevent the impact of dynamic partition changes
     std::string app_name_pcount = fmt::format("{}.{}", app_name, partition_num);
-    auto iter = _hotspot_calculator_store.find(app_name_count);
+    auto iter = _hotspot_calculator_store.find(app_name_pcount);
     if (iter != _hotspot_calculator_store.end()) {
         return iter->second;
     }
@@ -318,12 +318,12 @@ hotspot_calculator *info_collector::get_hotspot_calculator(const std::string &ap
         policy.reset(new hotspot_algo_qps_skew());
     } else {
         dwarn("hotspot detection is disabled");
-        _hotspot_calculator_store[app_name_count] = nullptr;
+        _hotspot_calculator_store[app_name_pcount] = nullptr;
         return nullptr;
     }
     hotspot_calculator *calculator =
-        new hotspot_calculator(app_name_count, partition_num, std::move(policy));
-    _hotspot_calculator_store[app_name_count] = calculator;
+        new hotspot_calculator(app_name_pcount, partition_num, std::move(policy));
+    _hotspot_calculator_store[app_name_pcount] = calculator;
     return calculator;
 }
 

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -102,13 +102,13 @@ info_collector::~info_collector()
 
 void info_collector::start()
 {
-    _app_stat_timer_task =
-        ::dsn::tasking::enqueue_timer(LPC_PEGASUS_APP_STAT_TIMER,
-                                      &_tracker,
-                                      [this] { on_app_stat(); },
-                                      std::chrono::seconds(_app_stat_interval_seconds),
-                                      0,
-                                      std::chrono::minutes(1));
+    _app_stat_timer_task = ::dsn::tasking::enqueue_timer(
+        LPC_PEGASUS_APP_STAT_TIMER,
+        &_tracker,
+        [this] { on_app_stat(); },
+        std::chrono::seconds(_app_stat_interval_seconds),
+        0,
+        std::chrono::minutes(1));
 
     _capacity_unit_stat_timer_task = ::dsn::tasking::enqueue_timer(
         LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
@@ -241,11 +241,12 @@ void info_collector::on_capacity_unit_stat(int remaining_retry_count)
                   "wait %u seconds to retry",
                   remaining_retry_count,
                   _capacity_unit_retry_wait_seconds);
-            ::dsn::tasking::enqueue(LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
-                                    &_tracker,
-                                    [=] { on_capacity_unit_stat(remaining_retry_count - 1); },
-                                    0,
-                                    std::chrono::seconds(_capacity_unit_retry_wait_seconds));
+            ::dsn::tasking::enqueue(
+                LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
+                &_tracker,
+                [=] { on_capacity_unit_stat(remaining_retry_count - 1); },
+                0,
+                std::chrono::seconds(_capacity_unit_retry_wait_seconds));
         } else {
             derror("get capacity unit stat failed, remaining_retry_count = 0, no retry anymore");
         }
@@ -288,11 +289,12 @@ void info_collector::on_storage_size_stat(int remaining_retry_count)
                   "wait %u seconds to retry",
                   remaining_retry_count,
                   _storage_size_retry_wait_seconds);
-            ::dsn::tasking::enqueue(LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
-                                    &_tracker,
-                                    [=] { on_storage_size_stat(remaining_retry_count - 1); },
-                                    0,
-                                    std::chrono::seconds(_storage_size_retry_wait_seconds));
+            ::dsn::tasking::enqueue(
+                LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
+                &_tracker,
+                [=] { on_storage_size_stat(remaining_retry_count - 1); },
+                0,
+                std::chrono::seconds(_storage_size_retry_wait_seconds));
         } else {
             derror("get storage size stat failed, remaining_retry_count = 0, no retry anymore");
         }
@@ -304,7 +306,8 @@ void info_collector::on_storage_size_stat(int remaining_retry_count)
 hotspot_calculator *info_collector::get_hotspot_calculator(const std::string &app_name,
                                                            const int partition_num)
 {
-    auto iter = _hotspot_calculator_store.find(app_name);
+    std::string app_name_count = app_name + std::string(partition_num);
+    auto iter = _hotspot_calculator_store.find(app_name_count);
     if (iter != _hotspot_calculator_store.end()) {
         return iter->second;
     }
@@ -315,12 +318,12 @@ hotspot_calculator *info_collector::get_hotspot_calculator(const std::string &ap
         policy.reset(new hotspot_algo_qps_skew());
     } else {
         dwarn("hotspot detection is disabled");
-        _hotspot_calculator_store[app_name] = nullptr;
+        _hotspot_calculator_store[app_name_count] = nullptr;
         return nullptr;
     }
     hotspot_calculator *calculator =
-        new hotspot_calculator(app_name, partition_num, std::move(policy));
-    _hotspot_calculator_store[app_name] = calculator;
+        new hotspot_calculator(app_name_count, partition_num, std::move(policy));
+    _hotspot_calculator_store[app_name_count] = calculator;
     return calculator;
 }
 

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -306,7 +306,7 @@ hotspot_calculator *info_collector::get_hotspot_calculator(const std::string &ap
                                                            const int partition_num)
 {
     // use appname+partition_num as a key can prevent the impact of dynamic partition changes
-    std::string app_name_count = fmt::format("{}.{}", app_name, partition_num);
+    std::string app_name_pcount = fmt::format("{}.{}", app_name, partition_num);
     auto iter = _hotspot_calculator_store.find(app_name_count);
     if (iter != _hotspot_calculator_store.end()) {
         return iter->second;

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -102,13 +102,13 @@ info_collector::~info_collector()
 
 void info_collector::start()
 {
-    _app_stat_timer_task = ::dsn::tasking::enqueue_timer(
-        LPC_PEGASUS_APP_STAT_TIMER,
-        &_tracker,
-        [this] { on_app_stat(); },
-        std::chrono::seconds(_app_stat_interval_seconds),
-        0,
-        std::chrono::minutes(1));
+    _app_stat_timer_task =
+        ::dsn::tasking::enqueue_timer(LPC_PEGASUS_APP_STAT_TIMER,
+                                      &_tracker,
+                                      [this] { on_app_stat(); },
+                                      std::chrono::seconds(_app_stat_interval_seconds),
+                                      0,
+                                      std::chrono::minutes(1));
 
     _capacity_unit_stat_timer_task = ::dsn::tasking::enqueue_timer(
         LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
@@ -241,12 +241,11 @@ void info_collector::on_capacity_unit_stat(int remaining_retry_count)
                   "wait %u seconds to retry",
                   remaining_retry_count,
                   _capacity_unit_retry_wait_seconds);
-            ::dsn::tasking::enqueue(
-                LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
-                &_tracker,
-                [=] { on_capacity_unit_stat(remaining_retry_count - 1); },
-                0,
-                std::chrono::seconds(_capacity_unit_retry_wait_seconds));
+            ::dsn::tasking::enqueue(LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
+                                    &_tracker,
+                                    [=] { on_capacity_unit_stat(remaining_retry_count - 1); },
+                                    0,
+                                    std::chrono::seconds(_capacity_unit_retry_wait_seconds));
         } else {
             derror("get capacity unit stat failed, remaining_retry_count = 0, no retry anymore");
         }
@@ -289,12 +288,11 @@ void info_collector::on_storage_size_stat(int remaining_retry_count)
                   "wait %u seconds to retry",
                   remaining_retry_count,
                   _storage_size_retry_wait_seconds);
-            ::dsn::tasking::enqueue(
-                LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
-                &_tracker,
-                [=] { on_storage_size_stat(remaining_retry_count - 1); },
-                0,
-                std::chrono::seconds(_storage_size_retry_wait_seconds));
+            ::dsn::tasking::enqueue(LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
+                                    &_tracker,
+                                    [=] { on_storage_size_stat(remaining_retry_count - 1); },
+                                    0,
+                                    std::chrono::seconds(_storage_size_retry_wait_seconds));
         } else {
             derror("get storage size stat failed, remaining_retry_count = 0, no retry anymore");
         }

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -103,13 +103,13 @@ info_collector::~info_collector()
 
 void info_collector::start()
 {
-    _app_stat_timer_task = ::dsn::tasking::enqueue_timer(
-        LPC_PEGASUS_APP_STAT_TIMER,
-        &_tracker,
-        [this] { on_app_stat(); },
-        std::chrono::seconds(_app_stat_interval_seconds),
-        0,
-        std::chrono::minutes(1));
+    _app_stat_timer_task =
+        ::dsn::tasking::enqueue_timer(LPC_PEGASUS_APP_STAT_TIMER,
+                                      &_tracker,
+                                      [this] { on_app_stat(); },
+                                      std::chrono::seconds(_app_stat_interval_seconds),
+                                      0,
+                                      std::chrono::minutes(1));
 
     _capacity_unit_stat_timer_task = ::dsn::tasking::enqueue_timer(
         LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
@@ -242,12 +242,11 @@ void info_collector::on_capacity_unit_stat(int remaining_retry_count)
                   "wait %u seconds to retry",
                   remaining_retry_count,
                   _capacity_unit_retry_wait_seconds);
-            ::dsn::tasking::enqueue(
-                LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
-                &_tracker,
-                [=] { on_capacity_unit_stat(remaining_retry_count - 1); },
-                0,
-                std::chrono::seconds(_capacity_unit_retry_wait_seconds));
+            ::dsn::tasking::enqueue(LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
+                                    &_tracker,
+                                    [=] { on_capacity_unit_stat(remaining_retry_count - 1); },
+                                    0,
+                                    std::chrono::seconds(_capacity_unit_retry_wait_seconds));
         } else {
             derror("get capacity unit stat failed, remaining_retry_count = 0, no retry anymore");
         }
@@ -290,12 +289,11 @@ void info_collector::on_storage_size_stat(int remaining_retry_count)
                   "wait %u seconds to retry",
                   remaining_retry_count,
                   _storage_size_retry_wait_seconds);
-            ::dsn::tasking::enqueue(
-                LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
-                &_tracker,
-                [=] { on_storage_size_stat(remaining_retry_count - 1); },
-                0,
-                std::chrono::seconds(_storage_size_retry_wait_seconds));
+            ::dsn::tasking::enqueue(LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
+                                    &_tracker,
+                                    [=] { on_storage_size_stat(remaining_retry_count - 1); },
+                                    0,
+                                    std::chrono::seconds(_storage_size_retry_wait_seconds));
         } else {
             derror("get storage size stat failed, remaining_retry_count = 0, no retry anymore");
         }

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <dsn/tool-api/group_address.h>
 #include <dsn/dist/replication/duplication_common.h>
+#include <dsn/dist/fmt_logging.h>
 
 #include "base/pegasus_const.h"
 #include "result_writer.h"
@@ -102,13 +103,13 @@ info_collector::~info_collector()
 
 void info_collector::start()
 {
-    _app_stat_timer_task =
-        ::dsn::tasking::enqueue_timer(LPC_PEGASUS_APP_STAT_TIMER,
-                                      &_tracker,
-                                      [this] { on_app_stat(); },
-                                      std::chrono::seconds(_app_stat_interval_seconds),
-                                      0,
-                                      std::chrono::minutes(1));
+    _app_stat_timer_task = ::dsn::tasking::enqueue_timer(
+        LPC_PEGASUS_APP_STAT_TIMER,
+        &_tracker,
+        [this] { on_app_stat(); },
+        std::chrono::seconds(_app_stat_interval_seconds),
+        0,
+        std::chrono::minutes(1));
 
     _capacity_unit_stat_timer_task = ::dsn::tasking::enqueue_timer(
         LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
@@ -241,11 +242,12 @@ void info_collector::on_capacity_unit_stat(int remaining_retry_count)
                   "wait %u seconds to retry",
                   remaining_retry_count,
                   _capacity_unit_retry_wait_seconds);
-            ::dsn::tasking::enqueue(LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
-                                    &_tracker,
-                                    [=] { on_capacity_unit_stat(remaining_retry_count - 1); },
-                                    0,
-                                    std::chrono::seconds(_capacity_unit_retry_wait_seconds));
+            ::dsn::tasking::enqueue(
+                LPC_PEGASUS_CAPACITY_UNIT_STAT_TIMER,
+                &_tracker,
+                [=] { on_capacity_unit_stat(remaining_retry_count - 1); },
+                0,
+                std::chrono::seconds(_capacity_unit_retry_wait_seconds));
         } else {
             derror("get capacity unit stat failed, remaining_retry_count = 0, no retry anymore");
         }
@@ -288,11 +290,12 @@ void info_collector::on_storage_size_stat(int remaining_retry_count)
                   "wait %u seconds to retry",
                   remaining_retry_count,
                   _storage_size_retry_wait_seconds);
-            ::dsn::tasking::enqueue(LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
-                                    &_tracker,
-                                    [=] { on_storage_size_stat(remaining_retry_count - 1); },
-                                    0,
-                                    std::chrono::seconds(_storage_size_retry_wait_seconds));
+            ::dsn::tasking::enqueue(
+                LPC_PEGASUS_STORAGE_SIZE_STAT_TIMER,
+                &_tracker,
+                [=] { on_storage_size_stat(remaining_retry_count - 1); },
+                0,
+                std::chrono::seconds(_storage_size_retry_wait_seconds));
         } else {
             derror("get storage size stat failed, remaining_retry_count = 0, no retry anymore");
         }
@@ -304,7 +307,7 @@ void info_collector::on_storage_size_stat(int remaining_retry_count)
 hotspot_calculator *info_collector::get_hotspot_calculator(const std::string &app_name,
                                                            const int partition_num)
 {
-    std::string app_name_count = app_name + std::to_string(partition_num);
+    std::string app_name_count = fmt::format({}.{}, app_name, partition_num);
     auto iter = _hotspot_calculator_store.find(app_name_count);
     if (iter != _hotspot_calculator_store.end()) {
         return iter->second;


### PR DESCRIPTION
if you do like this, there will be a core dump.
```bash
create aaa -p 8 -r 3
# wait a moment
drop aaa
create aaa -p 16 -r 3
```
Because the previous design cannot change the number of partitions of table after the Collector starts.
And now I store a hotspot_calculator named `app_name+partition_num`
