### PR TITLE
fix(shell/sds): NULL check before memset

### DIFF
--- a/src/shell/sds/sds.c
+++ b/src/shell/sds/sds.c
@@ -92,9 +92,9 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Potential use of NULL pointer.

### What is changed and how it works?
Check for NULL before `memset()`.
