### PR TITLE
feat(bulk-load): bulk load ingestion part3 - execute ingestion

### DIFF
--- a/src/base/pegasus_rpc_types.h
+++ b/src/base/pegasus_rpc_types.h
@@ -3,6 +3,7 @@
 // can be found in the LICENSE file in the root directory of this source tree.
 
 #include <dsn/cpp/rpc_holder.h>
+#include <dsn/dist/replication/replication_types.h>
 #include <rrdb/rrdb_types.h>
 #include <rrdb/rrdb.client.h>
 
@@ -26,5 +27,8 @@ using duplicate_rpc = dsn::apps::duplicate_rpc;
 
 using check_and_mutate_rpc =
     dsn::rpc_holder<dsn::apps::check_and_mutate_request, dsn::apps::check_and_mutate_response>;
+
+using ingestion_rpc =
+    dsn::rpc_holder<dsn::replication::ingestion_request, dsn::replication::ingestion_response>;
 
 } // namespace pegasus

--- a/src/server/config.ini
+++ b/src/server/config.ini
@@ -16,7 +16,7 @@
   name = replica
   arguments =
   ports = 34801
-  pools = THREAD_POOL_DEFAULT,THREAD_POOL_REPLICATION_LONG,THREAD_POOL_REPLICATION,THREAD_POOL_FD,THREAD_POOL_LOCAL_APP,THREAD_POOL_FDS_SERVICE,THREAD_POOL_COMPACT
+  pools = THREAD_POOL_DEFAULT,THREAD_POOL_REPLICATION_LONG,THREAD_POOL_REPLICATION,THREAD_POOL_FD,THREAD_POOL_LOCAL_APP,THREAD_POOL_FDS_SERVICE,THREAD_POOL_COMPACT,THREAD_POOL_INGESTION
   run = true
   count = 1
 
@@ -142,6 +142,12 @@
   worker_priority = THREAD_xPRIORITY_NORMAL
   worker_count = 8
 
+[threadpool.THREAD_POOL_INGESTION]
+  name = ingestion
+  partitioned = false
+  worker_priority = THREAD_xPRIORITY_NORMAL
+  worker_count = 24
+
 [meta_server]
   server_list = %{meta.server.list}
   cluster_root = /pegasus/%{cluster.name}
@@ -250,6 +256,9 @@
   ;; recommand using cluster name as the root
   cold_backup_root = %{cluster.name}
   max_concurrent_uploading_file_count = 10
+
+  bulk_load_provider_root = bulk_load_root
+  max_concurrent_bulk_load_downloading_count = 5
 
 [pegasus.server]
   rocksdb_verbose_log = false

--- a/src/server/config.min.ini
+++ b/src/server/config.min.ini
@@ -12,7 +12,7 @@
   type = replica
   name = replica
   ports = @REPLICA_PORT@
-  pools = THREAD_POOL_DEFAULT,THREAD_POOL_REPLICATION_LONG,THREAD_POOL_REPLICATION,THREAD_POOL_FD,THREAD_POOL_LOCAL_APP,THREAD_POOL_LOCAL_SERVICE,THREAD_POOL_COMPACT
+  pools = THREAD_POOL_DEFAULT,THREAD_POOL_REPLICATION_LONG,THREAD_POOL_REPLICATION,THREAD_POOL_FD,THREAD_POOL_LOCAL_APP,THREAD_POOL_LOCAL_SERVICE,THREAD_POOL_COMPACT,THREAD_POOL_INGESTION
 
 [apps.collector]
   name = collector
@@ -84,6 +84,11 @@
   name = compact
   worker_count = 1
 
+[threadpool.THREAD_POOL_INGESTION]
+  name = ingestion
+  partitioned = false
+  worker_count = 2
+
 [meta_server]
   server_list = @LOCAL_IP@:34601,@LOCAL_IP@:34602,@LOCAL_IP@:34603
   cluster_root = /pegasus/onebox/@LOCAL_IP@
@@ -103,6 +108,7 @@
   duplication_disabled = true
   cluster_name = onebox
   cold_backup_checkpoint_reserve_minutes = 10
+  bulk_load_provider_root = bulk_load_root
 
 [meta_server.apps.@APP_NAME@]
   app_name = @APP_NAME@

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -2670,5 +2670,13 @@ std::string pegasus_server_impl::dump_write_request(dsn::message_ex *request)
     return "default";
 }
 
+void pegasus_server_impl::set_ingestion_status(dsn::replication::ingestion_status::type status)
+{
+    ddebug_replica("ingestion status from {} to {}",
+                   dsn::enum_to_string(_ingestion_status),
+                   dsn::enum_to_string(status));
+    _ingestion_status = status;
+}
+
 } // namespace server
 } // namespace pegasus

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -158,6 +158,7 @@ public:
 
     std::string dump_write_request(dsn::message_ex *request) override;
 
+    // Not thread-safe
     void set_ingestion_status(dsn::replication::ingestion_status::type status) override;
 
     dsn::replication::ingestion_status::type get_ingestion_status() override

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -158,9 +158,9 @@ public:
 
     std::string dump_write_request(dsn::message_ex *request) override;
 
-    void set_ingestion_status(::dsn::replication::ingestion_status::type status) override;
+    void set_ingestion_status(dsn::replication::ingestion_status::type status) override;
 
-    ::dsn::replication::ingestion_status::type get_ingestion_status() override
+    dsn::replication::ingestion_status::type get_ingestion_status() override
     {
         return _ingestion_status;
     }
@@ -371,8 +371,8 @@ private:
 
     std::atomic<int32_t> _partition_version;
 
-    ::dsn::replication::ingestion_status::type _ingestion_status{
-        ::dsn::replication::ingestion_status::IS_INVALID};
+    dsn::replication::ingestion_status::type _ingestion_status{
+        dsn::replication::ingestion_status::IS_INVALID};
 
     dsn::task_tracker _tracker;
 

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -158,6 +158,13 @@ public:
 
     std::string dump_write_request(dsn::message_ex *request) override;
 
+    void set_ingestion_status(::dsn::replication::ingestion_status::type status) override;
+
+    ::dsn::replication::ingestion_status::type get_ingestion_status() override
+    {
+        return _ingestion_status;
+    }
+
 private:
     friend class manual_compact_service_test;
     friend class pegasus_compression_options_test;
@@ -363,6 +370,9 @@ private:
     pegasus_manual_compact_service _manual_compact_svc;
 
     std::atomic<int32_t> _partition_version;
+
+    ::dsn::replication::ingestion_status::type _ingestion_status{
+        ::dsn::replication::ingestion_status::IS_INVALID};
 
     dsn::task_tracker _tracker;
 

--- a/src/server/pegasus_server_write.cpp
+++ b/src/server/pegasus_server_write.cpp
@@ -66,6 +66,11 @@ int pegasus_server_write::on_batched_write_requests(dsn::message_ex **requests,
         auto rpc = check_and_mutate_rpc::auto_reply(requests[0]);
         return _write_svc->check_and_mutate(_decree, rpc.request(), rpc.response());
     }
+    if (rpc_code == dsn::apps::RPC_RRDB_RRDB_BULK_LOAD) {
+        dassert(count == 1, "count = %d", count);
+        auto rpc = ingestion_rpc::auto_reply(requests[0]);
+        return _write_svc->ingestion_files(_decree, rpc.request(), rpc.response());
+    }
 
     return on_batched_writes(requests, count);
 }

--- a/src/server/pegasus_write_service.h
+++ b/src/server/pegasus_write_service.h
@@ -7,6 +7,7 @@
 #include <dsn/perf_counter/perf_counter_wrapper.h>
 #include <dsn/dist/replication/replica_base.h>
 #include <dsn/dist/replication/duplication_common.h>
+#include <dsn/dist/replication/replication_types.h>
 
 #include "base/pegasus_value_schema.h"
 #include "base/pegasus_utils.h"
@@ -124,6 +125,11 @@ public:
     int duplicate(int64_t decree,
                   const dsn::apps::duplicate_request &update,
                   dsn::apps::duplicate_response &resp);
+
+    // Execute bulk load ingestion
+    int ingestion_files(int64_t decree,
+                        const dsn::replication::ingestion_request &req,
+                        dsn::replication::ingestion_response &resp);
 
     /// For batch write.
 

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -838,7 +838,6 @@ private:
                                             /*out*/ std::vector<std::string> &files_path)
     {
         for (const auto &f_meta : metadata.files) {
-            // const dsn::replication::file_meta &f_meta = *file;
             const std::string &file_name =
                 dsn::utils::filesystem::path_combine(bulk_load_dir, f_meta.name);
             if (dsn::utils::filesystem::verify_file(file_name, f_meta.md5, f_meta.size)) {

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -496,7 +496,7 @@ public:
     // \return ERR_OK: rocksdb ingestion succeed
     dsn::error_code ingestion_files(const int64_t decree,
                                     const std::string &bulk_load_dir,
-                                    const dsn::replication::bulk_load_metadata metadata)
+                                    const dsn::replication::bulk_load_metadata &metadata)
     {
         // verify external files before ingestion
         std::vector<std::string> sst_file_list;


### PR DESCRIPTION
This pull request is about how pegasus handle ingestion request.
Ingestion request is considered as a write request, but it is different from normal write request. Normal write request will not only write data but also write decree into rocksdb, but rocksdb ingestion won't write decree, so we should write an empty put to flush decree before execute ingestion. Besides, ingestion is time-consuming, it should not be executed in replication thread pool, so ingestion will execute in ingestion thread pool asynchronously, the result of ingestion will be got by ingestion_status. Before rocksdb do actual ingestion, we should verify files again.
