### PR TITLE
refactor: use rpc_holder to receive RPC in pegasus_server_impl

### DIFF
--- a/src/server/pegasus_read_service.h
+++ b/src/server/pegasus_read_service.h
@@ -6,6 +6,9 @@
 
 namespace pegasus {
 namespace server {
+
+typedef dsn::rpc_holder<::dsn::blob, ::dsn::apps::read_response> on_get_rpc;
+
 class pegasus_read_service : public dsn::replication::replication_app_base,
                              public dsn::replication::storage_serverlet<pegasus_read_service>
 {
@@ -23,8 +26,7 @@ public:
 protected:
     // all service handlers to be implemented further
     // RPC_RRDB_RRDB_GET
-    virtual void on_get(const ::dsn::blob &args,
-                        ::dsn::rpc_replier<dsn::apps::read_response> &reply) = 0;
+    virtual void on_get(on_get_rpc rpc) = 0;
     // RPC_RRDB_RRDB_MULTI_GET
     virtual void on_multi_get(const dsn::apps::multi_get_request &args,
                               ::dsn::rpc_replier<dsn::apps::multi_get_response> &reply) = 0;
@@ -45,7 +47,7 @@ protected:
 
     static void register_rpc_handlers()
     {
-        register_async_rpc_handler(dsn::apps::RPC_RRDB_RRDB_GET, "get", on_get);
+        register_rpc_handler_with_rpc_holder(dsn::apps::RPC_RRDB_RRDB_GET, "get", on_get);
         register_async_rpc_handler(dsn::apps::RPC_RRDB_RRDB_MULTI_GET, "multi_get", on_multi_get);
         register_async_rpc_handler(
             dsn::apps::RPC_RRDB_RRDB_SORTKEY_COUNT, "sortkey_count", on_sortkey_count);
@@ -58,12 +60,7 @@ protected:
     }
 
 private:
-    static void on_get(pegasus_read_service *svc,
-                       const ::dsn::blob &args,
-                       ::dsn::rpc_replier<dsn::apps::read_response> &reply)
-    {
-        svc->on_get(args, reply);
-    }
+    static void on_get(pegasus_read_service *svc, on_get_rpc rpc) { svc->on_get(rpc); }
     static void on_multi_get(pegasus_read_service *svc,
                              const dsn::apps::multi_get_request &args,
                              ::dsn::rpc_replier<dsn::apps::multi_get_response> &reply)

--- a/src/server/pegasus_read_service.h
+++ b/src/server/pegasus_read_service.h
@@ -7,12 +7,14 @@
 namespace pegasus {
 namespace server {
 
-typedef dsn::rpc_holder<::dsn::blob, ::dsn::apps::read_response> get_rpc;
-typedef dsn::rpc_holder<dsn::apps::multi_get_request, dsn::apps::multi_get_response> multi_get_rpc;
-typedef dsn::rpc_holder<::dsn::blob, dsn::apps::count_response> sortkey_count_rpc;
-typedef dsn::rpc_holder<::dsn::blob, dsn::apps::ttl_response> ttl_rpc;
-typedef dsn::rpc_holder<::dsn::apps::get_scanner_request, dsn::apps::scan_response> get_scanner_rpc;
-typedef dsn::rpc_holder<::dsn::apps::scan_request, dsn::apps::scan_response> scan_rpc;
+typedef ::dsn::rpc_holder<::dsn::blob, ::dsn::apps::read_response> get_rpc;
+typedef ::dsn::rpc_holder<dsn::apps::multi_get_request, dsn::apps::multi_get_response>
+    multi_get_rpc;
+typedef ::dsn::rpc_holder<::dsn::blob, dsn::apps::count_response> sortkey_count_rpc;
+typedef ::dsn::rpc_holder<::dsn::blob, dsn::apps::ttl_response> ttl_rpc;
+typedef ::dsn::rpc_holder<::dsn::apps::get_scanner_request, dsn::apps::scan_response>
+    get_scanner_rpc;
+typedef ::dsn::rpc_holder<::dsn::apps::scan_request, dsn::apps::scan_response> scan_rpc;
 
 class pegasus_read_service : public dsn::replication::replication_app_base,
                              public dsn::replication::storage_serverlet<pegasus_read_service>

--- a/src/server/pegasus_read_service.h
+++ b/src/server/pegasus_read_service.h
@@ -7,7 +7,12 @@
 namespace pegasus {
 namespace server {
 
-typedef dsn::rpc_holder<::dsn::blob, ::dsn::apps::read_response> on_get_rpc;
+typedef dsn::rpc_holder<::dsn::blob, ::dsn::apps::read_response> get_rpc;
+typedef dsn::rpc_holder<dsn::apps::multi_get_request, dsn::apps::multi_get_response> multi_get_rpc;
+typedef dsn::rpc_holder<::dsn::blob, dsn::apps::count_response> sortkey_count_rpc;
+typedef dsn::rpc_holder<::dsn::blob, dsn::apps::ttl_response> ttl_rpc;
+typedef dsn::rpc_holder<::dsn::apps::get_scanner_request, dsn::apps::scan_response> get_scanner_rpc;
+typedef dsn::rpc_holder<::dsn::apps::scan_request, dsn::apps::scan_response> scan_rpc;
 
 class pegasus_read_service : public dsn::replication::replication_app_base,
                              public dsn::replication::storage_serverlet<pegasus_read_service>
@@ -26,71 +31,51 @@ public:
 protected:
     // all service handlers to be implemented further
     // RPC_RRDB_RRDB_GET
-    virtual void on_get(on_get_rpc rpc) = 0;
+    virtual void on_get(get_rpc rpc) = 0;
     // RPC_RRDB_RRDB_MULTI_GET
-    virtual void on_multi_get(const dsn::apps::multi_get_request &args,
-                              ::dsn::rpc_replier<dsn::apps::multi_get_response> &reply) = 0;
+    virtual void on_multi_get(multi_get_rpc rpc) = 0;
     // RPC_RRDB_RRDB_SORTKEY_COUNT
-    virtual void on_sortkey_count(const ::dsn::blob &args,
-                                  ::dsn::rpc_replier<dsn::apps::count_response> &reply) = 0;
+    virtual void on_sortkey_count(sortkey_count_rpc rpc) = 0;
     // RPC_RRDB_RRDB_TTL
-    virtual void on_ttl(const ::dsn::blob &args,
-                        ::dsn::rpc_replier<dsn::apps::ttl_response> &reply) = 0;
+    virtual void on_ttl(ttl_rpc rpc) = 0;
     // RPC_RRDB_RRDB_GET_SCANNER
-    virtual void on_get_scanner(const dsn::apps::get_scanner_request &args,
-                                ::dsn::rpc_replier<dsn::apps::scan_response> &reply) = 0;
+    virtual void on_get_scanner(get_scanner_rpc rpc) = 0;
     // RPC_RRDB_RRDB_SCAN
-    virtual void on_scan(const dsn::apps::scan_request &args,
-                         ::dsn::rpc_replier<dsn::apps::scan_response> &reply) = 0;
+    virtual void on_scan(scan_rpc rpc) = 0;
     // RPC_RRDB_RRDB_CLEAR_SCANNER
     virtual void on_clear_scanner(const int64_t &args) = 0;
 
     static void register_rpc_handlers()
     {
         register_rpc_handler_with_rpc_holder(dsn::apps::RPC_RRDB_RRDB_GET, "get", on_get);
-        register_async_rpc_handler(dsn::apps::RPC_RRDB_RRDB_MULTI_GET, "multi_get", on_multi_get);
-        register_async_rpc_handler(
+        register_rpc_handler_with_rpc_holder(
+            dsn::apps::RPC_RRDB_RRDB_MULTI_GET, "multi_get", on_multi_get);
+        register_rpc_handler_with_rpc_holder(
             dsn::apps::RPC_RRDB_RRDB_SORTKEY_COUNT, "sortkey_count", on_sortkey_count);
-        register_async_rpc_handler(dsn::apps::RPC_RRDB_RRDB_TTL, "ttl", on_ttl);
-        register_async_rpc_handler(
+        register_rpc_handler_with_rpc_holder(dsn::apps::RPC_RRDB_RRDB_TTL, "ttl", on_ttl);
+        register_rpc_handler_with_rpc_holder(
             dsn::apps::RPC_RRDB_RRDB_GET_SCANNER, "get_scanner", on_get_scanner);
-        register_async_rpc_handler(dsn::apps::RPC_RRDB_RRDB_SCAN, "scan", on_scan);
+        register_rpc_handler_with_rpc_holder(dsn::apps::RPC_RRDB_RRDB_SCAN, "scan", on_scan);
         register_async_rpc_handler(
             dsn::apps::RPC_RRDB_RRDB_CLEAR_SCANNER, "clear_scanner", on_clear_scanner);
     }
 
 private:
-    static void on_get(pegasus_read_service *svc, on_get_rpc rpc) { svc->on_get(rpc); }
-    static void on_multi_get(pegasus_read_service *svc,
-                             const dsn::apps::multi_get_request &args,
-                             ::dsn::rpc_replier<dsn::apps::multi_get_response> &reply)
+    static void on_get(pegasus_read_service *svc, get_rpc rpc) { svc->on_get(rpc); }
+    static void on_multi_get(pegasus_read_service *svc, multi_get_rpc rpc)
     {
-        svc->on_multi_get(args, reply);
+        svc->on_multi_get(rpc);
     }
-    static void on_sortkey_count(pegasus_read_service *svc,
-                                 const ::dsn::blob &args,
-                                 ::dsn::rpc_replier<dsn::apps::count_response> &reply)
+    static void on_sortkey_count(pegasus_read_service *svc, sortkey_count_rpc rpc)
     {
-        svc->on_sortkey_count(args, reply);
+        svc->on_sortkey_count(rpc);
     }
-    static void on_ttl(pegasus_read_service *svc,
-                       const ::dsn::blob &args,
-                       ::dsn::rpc_replier<dsn::apps::ttl_response> &reply)
+    static void on_ttl(pegasus_read_service *svc, ttl_rpc rpc) { svc->on_ttl(rpc); }
+    static void on_get_scanner(pegasus_read_service *svc, get_scanner_rpc rpc)
     {
-        svc->on_ttl(args, reply);
+        svc->on_get_scanner(rpc);
     }
-    static void on_get_scanner(pegasus_read_service *svc,
-                               const dsn::apps::get_scanner_request &args,
-                               ::dsn::rpc_replier<dsn::apps::scan_response> &reply)
-    {
-        svc->on_get_scanner(args, reply);
-    }
-    static void on_scan(pegasus_read_service *svc,
-                        const dsn::apps::scan_request &args,
-                        ::dsn::rpc_replier<dsn::apps::scan_response> &reply)
-    {
-        svc->on_scan(args, reply);
-    }
+    static void on_scan(pegasus_read_service *svc, scan_rpc rpc) { svc->on_scan(rpc); }
     static void on_clear_scanner(pegasus_read_service *svc, const int64_t &args)
     {
         svc->on_clear_scanner(args);

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -237,7 +237,7 @@ int pegasus_server_impl::on_batched_write_requests(int64_t decree,
     return _server_write->on_batched_write_requests(requests, count, decree, timestamp);
 }
 
-void pegasus_server_impl::on_get(on_get_rpc rpc)
+void pegasus_server_impl::on_get(get_rpc rpc)
 {
     const ::dsn::blob &key = rpc.request();
     dassert(_is_open, "");
@@ -315,14 +315,14 @@ void pegasus_server_impl::on_get(on_get_rpc rpc)
     _pfc_get_latency->set(dsn_now_ns() - start_time);
 }
 
-void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &request,
-                                       ::dsn::rpc_replier<::dsn::apps::multi_get_response> &reply)
+void pegasus_server_impl::on_multi_get(multi_get_rpc rpc)
 {
     dassert(_is_open, "");
     _pfc_multi_get_qps->increment();
     uint64_t start_time = dsn_now_ns();
 
-    ::dsn::apps::multi_get_response resp;
+    const auto &request = rpc.request();
+    auto &resp = rpc.response();
     resp.app_id = _gpid.get_app_id();
     resp.partition_index = _gpid.get_partition_index();
     resp.server = _primary_address;
@@ -331,12 +331,11 @@ void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &req
         derror("%s: invalid argument for multi_get from %s: "
                "sort key filter type %d not supported",
                replica_name(),
-               reply.to_address().to_string(),
+               rpc.remote_address().to_string(),
                request.sort_key_filter_type);
         resp.error = rocksdb::Status::kInvalidArgument;
         _cu_calculator->add_multi_get_cu(resp.error, request.hash_key, resp.kvs);
         _pfc_multi_get_latency->set(dsn_now_ns() - start_time);
-        reply(resp);
         return;
     }
 
@@ -405,7 +404,7 @@ void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &req
                       "sort_key_filter_type = %s, sort_key_filter_pattern = \"%s\", "
                       "final_start = \"%s\" (%s), final_stop = \"%s\" (%s)",
                       replica_name(),
-                      reply.to_address().to_string(),
+                      rpc.remote_address().to_string(),
                       ::pegasus::utils::c_escape_string(request.hash_key).c_str(),
                       ::pegasus::utils::c_escape_string(request.start_sortkey).c_str(),
                       request.start_inclusive ? "inclusive" : "exclusive",
@@ -422,7 +421,7 @@ void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &req
             resp.error = rocksdb::Status::kOk;
             _cu_calculator->add_multi_get_cu(resp.error, request.hash_key, resp.kvs);
             _pfc_multi_get_latency->set(dsn_now_ns() - start_time);
-            reply(resp);
+
             return;
         }
 
@@ -566,7 +565,7 @@ void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &req
                 derror("%s: rocksdb scan failed for multi_get from %s: "
                        "hash_key = \"%s\", reverse = %s, error = %s",
                        replica_name(),
-                       reply.to_address().to_string(),
+                       rpc.remote_address().to_string(),
                        ::pegasus::utils::c_escape_string(request.hash_key).c_str(),
                        request.reverse ? "true" : "false",
                        it->status().ToString().c_str());
@@ -574,7 +573,7 @@ void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &req
                 derror("%s: rocksdb scan failed for multi_get from %s: "
                        "reverse = %s, error = %s",
                        replica_name(),
-                       reply.to_address().to_string(),
+                       rpc.remote_address().to_string(),
                        request.reverse ? "true" : "false",
                        it->status().ToString().c_str());
             }
@@ -585,7 +584,7 @@ void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &req
             if (limiter->exceed_limit()) {
                 dwarn_replica(
                     "rocksdb abnormal scan from {}: time_used({}ns) VS time_threshold({}ns)",
-                    reply.to_address().to_string(),
+                    rpc.remote_address().to_string(),
                     limiter->duration_time(),
                     limiter->max_duration_time());
             }
@@ -616,14 +615,14 @@ void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &req
                     derror("%s: rocksdb get failed for multi_get from %s: "
                            "hash_key = \"%s\", sort_key = \"%s\", error = %s",
                            replica_name(),
-                           reply.to_address().to_string(),
+                           rpc.remote_address().to_string(),
                            ::pegasus::utils::c_escape_string(request.hash_key).c_str(),
                            ::pegasus::utils::c_escape_string(request.sort_keys[i]).c_str(),
                            status.ToString().c_str());
                 } else if (!status.IsNotFound()) {
                     derror("%s: rocksdb get failed for multi_get from %s: error = %s",
                            replica_name(),
-                           reply.to_address().to_string(),
+                           rpc.remote_address().to_string(),
                            status.ToString().c_str());
                 }
             }
@@ -635,7 +634,7 @@ void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &req
                     if (_verbose_log) {
                         derror("%s: rocksdb data expired for multi_get from %s",
                                replica_name(),
-                               reply.to_address().to_string());
+                               rpc.remote_address().to_string());
                     }
                     status = rocksdb::Status::NotFound();
                 }
@@ -688,7 +687,7 @@ void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &req
             "max_kv_count = {}, max_kv_size = {}, reverse = {}, "
             "result_count = {}, result_size = {}, iteration_count = {}, "
             "expire_count = {}, filter_count = {}, time_used = {} ns",
-            reply.to_address().to_string(),
+            rpc.remote_address().to_string(),
             ::pegasus::utils::c_escape_string(request.hash_key),
             ::pegasus::utils::c_escape_string(request.start_sortkey),
             request.start_inclusive ? "inclusive" : "exclusive",
@@ -717,19 +716,17 @@ void pegasus_server_impl::on_multi_get(const ::dsn::apps::multi_get_request &req
 
     _cu_calculator->add_multi_get_cu(resp.error, request.hash_key, resp.kvs);
     _pfc_multi_get_latency->set(dsn_now_ns() - start_time);
-
-    reply(resp);
 }
 
-void pegasus_server_impl::on_sortkey_count(const ::dsn::blob &hash_key,
-                                           ::dsn::rpc_replier<::dsn::apps::count_response> &reply)
+void pegasus_server_impl::on_sortkey_count(sortkey_count_rpc rpc)
 {
     dassert(_is_open, "");
 
     _pfc_scan_qps->increment();
     uint64_t start_time = dsn_now_ns();
 
-    ::dsn::apps::count_response resp;
+    const auto &hash_key = rpc.request();
+    auto resp = rpc.response();
     resp.app_id = _gpid.get_app_id();
     resp.partition_index = _gpid.get_partition_index();
     resp.server = _primary_address;
@@ -760,7 +757,7 @@ void pegasus_server_impl::on_sortkey_count(const ::dsn::blob &hash_key,
             if (_verbose_log) {
                 derror("%s: rocksdb data expired for sortkey_count from %s",
                        replica_name(),
-                       reply.to_address().to_string());
+                       rpc.remote_address().to_string());
             }
         } else {
             resp.count++;
@@ -778,19 +775,19 @@ void pegasus_server_impl::on_sortkey_count(const ::dsn::blob &hash_key,
             derror("%s: rocksdb scan failed for sortkey_count from %s: "
                    "hash_key = \"%s\", error = %s",
                    replica_name(),
-                   reply.to_address().to_string(),
+                   rpc.remote_address().to_string(),
                    ::pegasus::utils::c_escape_string(hash_key).c_str(),
                    it->status().ToString().c_str());
         } else {
             derror("%s: rocksdb scan failed for sortkey_count from %s: error = %s",
                    replica_name(),
-                   reply.to_address().to_string(),
+                   rpc.remote_address().to_string(),
                    it->status().ToString().c_str());
         }
         resp.count = 0;
     } else if (limiter->exceed_limit()) {
         dwarn_replica("rocksdb abnormal scan from {}: time_used({}ns) VS time_threshold({}ns)",
-                      reply.to_address().to_string(),
+                      rpc.remote_address().to_string(),
                       limiter->duration_time(),
                       limiter->max_duration_time());
         resp.count = -1;
@@ -798,16 +795,14 @@ void pegasus_server_impl::on_sortkey_count(const ::dsn::blob &hash_key,
 
     _cu_calculator->add_sortkey_count_cu(resp.error);
     _pfc_scan_latency->set(dsn_now_ns() - start_time);
-
-    reply(resp);
 }
 
-void pegasus_server_impl::on_ttl(const ::dsn::blob &key,
-                                 ::dsn::rpc_replier<::dsn::apps::ttl_response> &reply)
+void pegasus_server_impl::on_ttl(ttl_rpc rpc)
 {
     dassert(_is_open, "");
 
-    ::dsn::apps::ttl_response resp;
+    const auto &key = rpc.request();
+    auto &resp = rpc.response();
     resp.app_id = _gpid.get_app_id();
     resp.partition_index = _gpid.get_partition_index();
     resp.server = _primary_address;
@@ -825,7 +820,7 @@ void pegasus_server_impl::on_ttl(const ::dsn::blob &key,
             if (_verbose_log) {
                 derror("%s: rocksdb data expired for ttl from %s",
                        replica_name(),
-                       reply.to_address().to_string());
+                       rpc.remote_address().to_string());
             }
             status = rocksdb::Status::NotFound();
         }
@@ -838,14 +833,14 @@ void pegasus_server_impl::on_ttl(const ::dsn::blob &key,
             derror("%s: rocksdb get failed for ttl from %s: "
                    "hash_key = \"%s\", sort_key = \"%s\", error = %s",
                    replica_name(),
-                   reply.to_address().to_string(),
+                   rpc.remote_address().to_string(),
                    ::pegasus::utils::c_escape_string(hash_key).c_str(),
                    ::pegasus::utils::c_escape_string(sort_key).c_str(),
                    status.ToString().c_str());
         } else if (!status.IsNotFound()) {
             derror("%s: rocksdb get failed for ttl from %s: error = %s",
                    replica_name(),
-                   reply.to_address().to_string(),
+                   rpc.remote_address().to_string(),
                    status.ToString().c_str());
         }
     }
@@ -861,18 +856,16 @@ void pegasus_server_impl::on_ttl(const ::dsn::blob &key,
     }
 
     _cu_calculator->add_ttl_cu(resp.error);
-
-    reply(resp);
 }
 
-void pegasus_server_impl::on_get_scanner(const ::dsn::apps::get_scanner_request &request,
-                                         ::dsn::rpc_replier<::dsn::apps::scan_response> &reply)
+void pegasus_server_impl::on_get_scanner(get_scanner_rpc rpc)
 {
     dassert(_is_open, "");
     _pfc_scan_qps->increment();
     uint64_t start_time = dsn_now_ns();
 
-    ::dsn::apps::scan_response resp;
+    const auto &request = rpc.request();
+    auto &resp = rpc.response();
     resp.app_id = _gpid.get_app_id();
     resp.partition_index = _gpid.get_partition_index();
     resp.server = _primary_address;
@@ -881,24 +874,24 @@ void pegasus_server_impl::on_get_scanner(const ::dsn::apps::get_scanner_request 
         derror("%s: invalid argument for get_scanner from %s: "
                "hash key filter type %d not supported",
                replica_name(),
-               reply.to_address().to_string(),
+               rpc.remote_address().to_string(),
                request.hash_key_filter_type);
         resp.error = rocksdb::Status::kInvalidArgument;
         _cu_calculator->add_scan_cu(resp.error, resp.kvs);
         _pfc_scan_latency->set(dsn_now_ns() - start_time);
-        reply(resp);
+
         return;
     }
     if (!is_filter_type_supported(request.sort_key_filter_type)) {
         derror("%s: invalid argument for get_scanner from %s: "
                "sort key filter type %d not supported",
                replica_name(),
-               reply.to_address().to_string(),
+               rpc.remote_address().to_string(),
                request.sort_key_filter_type);
         resp.error = rocksdb::Status::kInvalidArgument;
         _cu_calculator->add_scan_cu(resp.error, resp.kvs);
         _pfc_scan_latency->set(dsn_now_ns() - start_time);
-        reply(resp);
+
         return;
     }
 
@@ -947,7 +940,7 @@ void pegasus_server_impl::on_get_scanner(const ::dsn::apps::get_scanner_request 
             dwarn("%s: empty key range for get_scanner from %s: "
                   "start_key = \"%s\" (%s), stop_key = \"%s\" (%s)",
                   replica_name(),
-                  reply.to_address().to_string(),
+                  rpc.remote_address().to_string(),
                   ::pegasus::utils::c_escape_string(request.start_key).c_str(),
                   request.start_inclusive ? "inclusive" : "exclusive",
                   ::pegasus::utils::c_escape_string(request.stop_key).c_str(),
@@ -956,7 +949,7 @@ void pegasus_server_impl::on_get_scanner(const ::dsn::apps::get_scanner_request 
         resp.error = rocksdb::Status::kOk;
         _cu_calculator->add_scan_cu(resp.error, resp.kvs);
         _pfc_scan_latency->set(dsn_now_ns() - start_time);
-        reply(resp);
+
         return;
     }
 
@@ -1034,7 +1027,7 @@ void pegasus_server_impl::on_get_scanner(const ::dsn::apps::get_scanner_request 
                    "start_key = \"%s\" (%s), stop_key = \"%s\" (%s), "
                    "batch_size = %d, read_count = %d, error = %s",
                    replica_name(),
-                   reply.to_address().to_string(),
+                   rpc.remote_address().to_string(),
                    ::pegasus::utils::c_escape_string(start).c_str(),
                    request.start_inclusive ? "inclusive" : "exclusive",
                    ::pegasus::utils::c_escape_string(stop).c_str(),
@@ -1045,7 +1038,7 @@ void pegasus_server_impl::on_get_scanner(const ::dsn::apps::get_scanner_request 
         } else {
             derror("%s: rocksdb scan failed for get_scanner from %s: error = %s",
                    replica_name(),
-                   reply.to_address().to_string(),
+                   rpc.remote_address().to_string(),
                    it->status().ToString().c_str());
         }
         resp.kvs.clear();
@@ -1054,7 +1047,7 @@ void pegasus_server_impl::on_get_scanner(const ::dsn::apps::get_scanner_request 
         resp.error = rocksdb::Status::kIncomplete;
         dwarn_replica("rocksdb abnormal scan from {}: batch_count={}, time_used_ns({}) VS "
                       "time_threshold_ns({})",
-                      reply.to_address().to_string(),
+                      rpc.remote_address().to_string(),
                       batch_count,
                       limiter->duration_time(),
                       limiter->max_duration_time());
@@ -1096,18 +1089,15 @@ void pegasus_server_impl::on_get_scanner(const ::dsn::apps::get_scanner_request 
 
     _cu_calculator->add_scan_cu(resp.error, resp.kvs);
     _pfc_scan_latency->set(dsn_now_ns() - start_time);
-
-    reply(resp);
 }
 
-void pegasus_server_impl::on_scan(const ::dsn::apps::scan_request &request,
-                                  ::dsn::rpc_replier<::dsn::apps::scan_response> &reply)
+void pegasus_server_impl::on_scan(scan_rpc rpc)
 {
     dassert(_is_open, "");
     _pfc_scan_qps->increment();
     uint64_t start_time = dsn_now_ns();
-
-    ::dsn::apps::scan_response resp;
+    const auto &request = rpc.request();
+    auto &resp = rpc.response();
     resp.app_id = _gpid.get_app_id();
     resp.partition_index = _gpid.get_partition_index();
     resp.server = _primary_address;
@@ -1184,7 +1174,7 @@ void pegasus_server_impl::on_scan(const ::dsn::apps::scan_request &request,
                        "context_id= %" PRId64 ", stop_key = \"%s\" (%s), "
                        "batch_size = %d, read_count = %d, error = %s",
                        replica_name(),
-                       reply.to_address().to_string(),
+                       rpc.remote_address().to_string(),
                        request.context_id,
                        ::pegasus::utils::c_escape_string(stop).c_str(),
                        stop_inclusive ? "inclusive" : "exclusive",
@@ -1194,7 +1184,7 @@ void pegasus_server_impl::on_scan(const ::dsn::apps::scan_request &request,
             } else {
                 derror("%s: rocksdb scan failed for scan from %s: error = %s",
                        replica_name(),
-                       reply.to_address().to_string(),
+                       rpc.remote_address().to_string(),
                        it->status().ToString().c_str());
             }
             resp.kvs.clear();
@@ -1203,7 +1193,7 @@ void pegasus_server_impl::on_scan(const ::dsn::apps::scan_request &request,
             resp.error = rocksdb::Status::kIncomplete;
             dwarn_replica("rocksdb abnormal scan from {}: batch_count={}, time_used({}ns) VS "
                           "time_threshold({}ns)",
-                          reply.to_address().to_string(),
+                          rpc.remote_address().to_string(),
                           batch_count,
                           limiter->duration_time(),
                           limiter->max_duration_time());
@@ -1233,8 +1223,6 @@ void pegasus_server_impl::on_scan(const ::dsn::apps::scan_request &request,
 
     _cu_calculator->add_scan_cu(resp.error, resp.kvs);
     _pfc_scan_latency->set(dsn_now_ns() - start_time);
-
-    reply(resp);
 }
 
 void pegasus_server_impl::on_clear_scanner(const int64_t &args) { _context_cache.fetch(args); }

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -239,12 +239,12 @@ int pegasus_server_impl::on_batched_write_requests(int64_t decree,
 
 void pegasus_server_impl::on_get(get_rpc rpc)
 {
-    const ::dsn::blob &key = rpc.request();
     dassert(_is_open, "");
     _pfc_get_qps->increment();
     uint64_t start_time = dsn_now_ns();
 
-    ::dsn::apps::read_response &resp = rpc.response();
+    const auto &key = rpc.request();
+    auto &resp = rpc.response();
     resp.app_id = _gpid.get_app_id();
     resp.partition_index = _gpid.get_partition_index();
     resp.server = _primary_address;
@@ -726,7 +726,7 @@ void pegasus_server_impl::on_sortkey_count(sortkey_count_rpc rpc)
     uint64_t start_time = dsn_now_ns();
 
     const auto &hash_key = rpc.request();
-    auto resp = rpc.response();
+    auto &resp = rpc.response();
     resp.app_id = _gpid.get_app_id();
     resp.partition_index = _gpid.get_partition_index();
     resp.server = _primary_address;

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -43,8 +43,7 @@ public:
     ~pegasus_server_impl() override;
 
     // the following methods may set physical error if internal error occurs
-    void on_get(const ::dsn::blob &key,
-                ::dsn::rpc_replier<::dsn::apps::read_response> &reply) override;
+    void on_get(on_get_rpc rpc) override;
     void on_multi_get(const ::dsn::apps::multi_get_request &args,
                       ::dsn::rpc_replier<::dsn::apps::multi_get_response> &reply) override;
     void on_sortkey_count(const ::dsn::blob &args,

--- a/src/server/pegasus_server_impl.h
+++ b/src/server/pegasus_server_impl.h
@@ -43,17 +43,12 @@ public:
     ~pegasus_server_impl() override;
 
     // the following methods may set physical error if internal error occurs
-    void on_get(on_get_rpc rpc) override;
-    void on_multi_get(const ::dsn::apps::multi_get_request &args,
-                      ::dsn::rpc_replier<::dsn::apps::multi_get_response> &reply) override;
-    void on_sortkey_count(const ::dsn::blob &args,
-                          ::dsn::rpc_replier<::dsn::apps::count_response> &reply) override;
-    void on_ttl(const ::dsn::blob &key,
-                ::dsn::rpc_replier<::dsn::apps::ttl_response> &reply) override;
-    void on_get_scanner(const ::dsn::apps::get_scanner_request &args,
-                        ::dsn::rpc_replier<::dsn::apps::scan_response> &reply) override;
-    void on_scan(const ::dsn::apps::scan_request &args,
-                 ::dsn::rpc_replier<::dsn::apps::scan_response> &reply) override;
+    void on_get(get_rpc rpc) override;
+    void on_multi_get(multi_get_rpc rpc) override;
+    void on_sortkey_count(sortkey_count_rpc rpc) override;
+    void on_ttl(ttl_rpc rpc) override;
+    void on_get_scanner(get_scanner_rpc rpc) override;
+    void on_scan(scan_rpc rpc) override;
     void on_clear_scanner(const int64_t &args) override;
 
     // input:

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -41,8 +41,9 @@ public:
             // do on_get/on_multi_get operation,
             long before_count = _server->_pfc_recent_abnormal_count->get_integer_value();
             if (!test.is_multi_get) {
-                ::dsn::rpc_replier<::dsn::apps::read_response> reply(nullptr);
-                _server->on_get(test_key, reply);
+                on_get_rpc rpc;
+                test_key = rpc.request();
+                _server->on_get(rpc);
             } else {
                 ::dsn::apps::multi_get_request request;
                 request.__set_hash_key(dsn::blob(test_hash_key.data(), 0, test_hash_key.size()));

--- a/src/server/test/pegasus_server_impl_test.cpp
+++ b/src/server/test/pegasus_server_impl_test.cpp
@@ -41,15 +41,16 @@ public:
             // do on_get/on_multi_get operation,
             long before_count = _server->_pfc_recent_abnormal_count->get_integer_value();
             if (!test.is_multi_get) {
-                on_get_rpc rpc;
-                test_key = rpc.request();
+                get_rpc rpc(dsn::make_unique<dsn::blob>(test_key), dsn::apps::RPC_RRDB_RRDB_GET);
                 _server->on_get(rpc);
             } else {
                 ::dsn::apps::multi_get_request request;
                 request.__set_hash_key(dsn::blob(test_hash_key.data(), 0, test_hash_key.size()));
                 request.__set_sort_keys({dsn::blob(test_sort_key.data(), 0, test_sort_key.size())});
                 ::dsn::rpc_replier<::dsn::apps::multi_get_response> reply(nullptr);
-                _server->on_multi_get(request, reply);
+                multi_get_rpc rpc(dsn::make_unique<::dsn::apps::multi_get_request>(request),
+                                  dsn::apps::RPC_RRDB_RRDB_MULTI_GET);
+                _server->on_multi_get(rpc);
             }
             long after_count = _server->_pfc_recent_abnormal_count->get_integer_value();
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR plans to replace `rpc_replier` to `rpc_holder` in `pegasus_server_impl`

### What is changed and how it works?
just a refactor

