### PR TITLE
feat(rocksdb): Remove all calls of Pegasus introduced APIs on RocksDB

### DIFF
--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -10,14 +10,6 @@
 namespace pegasus {
 namespace server {
 
-DSN_DEFINE_string("pegasus.server",
-                  get_meta_store_type,
-                  "metacf",
-                  "Where to get meta data, now support 'manifest' and 'metacf'");
-DSN_DEFINE_validator(get_meta_store_type, [](const char *type) {
-    return strcmp(type, "manifest") == 0 || strcmp(type, "metacf") == 0;
-});
-
 const std::string meta_store::DATA_VERSION = "pegasus_data_version";
 const std::string meta_store::LAST_FLUSHED_DECREE = "pegasus_last_flushed_decree";
 const std::string meta_store::LAST_MANUAL_COMPACT_FINISH_TIME =
@@ -30,58 +22,31 @@ meta_store::meta_store(pegasus_server_impl *server,
 {
     // disable write ahead logging as replication handles logging instead now
     _wt_opts.disableWAL = true;
-    _get_meta_store_type =
-        (strcmp(FLAGS_get_meta_store_type, "manifest") == 0 ? meta_store_type::kManifestOnly
-                                                            : meta_store_type::kMetaCFOnly);
 }
 
 uint64_t meta_store::get_last_flushed_decree() const
 {
-    switch (_get_meta_store_type) {
-    case meta_store_type::kManifestOnly:
-        return _db->GetLastFlushedDecree();
-    case meta_store_type::kMetaCFOnly: {
-        uint64_t last_flushed_decree = 0;
-        auto ec = get_value_from_meta_cf(true, LAST_FLUSHED_DECREE, &last_flushed_decree);
-        dcheck_eq_replica(::dsn::ERR_OK, ec);
-        return last_flushed_decree;
-    }
-    default:
-        __builtin_unreachable();
-    }
+    uint64_t last_flushed_decree = 0;
+    auto ec = get_value_from_meta_cf(true, LAST_FLUSHED_DECREE, &last_flushed_decree);
+    dcheck_eq_replica(::dsn::ERR_OK, ec);
+    return last_flushed_decree;
 }
 
 uint32_t meta_store::get_data_version() const
 {
-    switch (_get_meta_store_type) {
-    case meta_store_type::kManifestOnly:
-        return _db->GetPegasusDataVersion();
-    case meta_store_type::kMetaCFOnly: {
-        uint64_t pegasus_data_version = 0;
-        auto ec = get_value_from_meta_cf(false, DATA_VERSION, &pegasus_data_version);
-        dcheck_eq_replica(::dsn::ERR_OK, ec);
-        return static_cast<uint32_t>(pegasus_data_version);
-    }
-    default:
-        __builtin_unreachable();
-    }
+    uint64_t pegasus_data_version = 0;
+    auto ec = get_value_from_meta_cf(false, DATA_VERSION, &pegasus_data_version);
+    dcheck_eq_replica(::dsn::ERR_OK, ec);
+    return static_cast<uint32_t>(pegasus_data_version);
 }
 
 uint64_t meta_store::get_last_manual_compact_finish_time() const
 {
-    switch (_get_meta_store_type) {
-    case meta_store_type::kManifestOnly:
-        return _db->GetLastManualCompactFinishTime();
-    case meta_store_type::kMetaCFOnly: {
-        uint64_t last_manual_compact_finish_time = 0;
-        auto ec = get_value_from_meta_cf(
-            false, LAST_MANUAL_COMPACT_FINISH_TIME, &last_manual_compact_finish_time);
-        dcheck_eq_replica(::dsn::ERR_OK, ec);
-        return last_manual_compact_finish_time;
-    }
-    default:
-        __builtin_unreachable();
-    }
+    uint64_t last_manual_compact_finish_time = 0;
+    auto ec = get_value_from_meta_cf(
+        false, LAST_MANUAL_COMPACT_FINISH_TIME, &last_manual_compact_finish_time);
+    dcheck_eq_replica(::dsn::ERR_OK, ec);
+    return last_manual_compact_finish_time;
 }
 
 uint64_t meta_store::get_decree_from_readonly_db(rocksdb::DB *db,

--- a/src/server/meta_store.h
+++ b/src/server/meta_store.h
@@ -23,13 +23,6 @@ class pegasus_server_impl;
 class meta_store : public dsn::replication::replica_base
 {
 public:
-    enum class meta_store_type
-    {
-        kManifestOnly = 0,
-        kMetaCFOnly,
-        kBothManifestAndMetaCF,
-    };
-
     meta_store(pegasus_server_impl *server, rocksdb::DB *db, rocksdb::ColumnFamilyHandle *meta_cf);
 
     uint64_t get_last_flushed_decree() const;
@@ -63,8 +56,6 @@ private:
     rocksdb::DB *_db;
     rocksdb::ColumnFamilyHandle *_meta_cf;
     rocksdb::WriteOptions _wt_opts;
-
-    meta_store_type _get_meta_store_type;
 };
 
 } // namespace server

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -103,8 +103,6 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
         _rng_rd_opts.rocksdb_iteration_threshold_time_ms_in_config;
 
     // init rocksdb::DBOptions
-    _db_opts.pegasus_data = true;
-    _db_opts.pegasus_data_version = _pegasus_data_version;
     _db_opts.create_if_missing = true;
     // atomic flush data CF and meta CF, aim to keep consistency of 'last flushed decree' in meta CF
     // and data in data CF.

--- a/src/server/pegasus_write_service_impl.h
+++ b/src/server/pegasus_write_service_impl.h
@@ -668,7 +668,6 @@ private:
             return status.code();
         }
 
-        _wt_opts.given_decree = static_cast<uint64_t>(decree);
         status = _db->Write(_wt_opts, &_batch);
         if (dsn_unlikely(!status.ok())) {
             derror_rocksdb("Write", status.ToString(), "write rocksdb error, decree: {}", decree);


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Use official RocksdDB

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
Test compatibility with 2.0.0:

Code changes

- Has exported function/method change
No
- Has exported variable/fields change
No
- Has interface methods change
No
- Has persistent data change
Yes.
Meta data (Pegasus data version, last manual compact finish timestamp, dcree) will **NOT** write to RocksDB's manifest anymore.

Side effects

- Possible performance regression
No
- Increased code complexity
No
- Breaking backward compatibility
**Upgrade:**
1.x -> this version: forbidden (server will core)
2.0 -> this version: compatible
**Downgrade:**
this version -> 1.x: forbidden (server will run with error, table can not be healthy, cause 1.x can't open RocksDB with multi-CFs)
this version -> 2.0: partial compatible, and config `[pegasus.server].get_meta_store_type` should be `metacf ` in order to read meta data from meta CF.

Related changes

- Need to cherry-pick to the release branch
Yes
- Need to update the documentation.
Yes
- Need to be included in the release note
Yes