### PR TITLE
refactor: modify the dependent lib name which are generated by rdsn

### DIFF
--- a/src/client_lib/CMakeLists.txt
+++ b/src/client_lib/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(pegasus_client_impl_objects PUBLIC $<TARGET_PROPERTY:
 set(pegasus_client_static_lib ${CMAKE_CURRENT_BINARY_DIR}/libpegasus_client_static.a)
 add_custom_target(combine_lib
     COMMAND ar -x ${DSN_ROOT}/lib/libdsn_runtime.a
-    COMMAND ar -x ${DSN_ROOT}/lib/libdsn_replication_client.a
+    COMMAND ar -x ${DSN_ROOT}/lib/libdsn_client.a
     COMMAND ar -x ${DSN_ROOT}/lib/libdsn_replication_common.a
     COMMAND ar -x ${DSN_THIRDPARTY_ROOT}/lib/libthrift.a
     COMMAND ar -x ${CMAKE_BINARY_DIR}/base/libpegasus_base.a
@@ -36,7 +36,7 @@ add_library(pegasus_client_shared SHARED $<TARGET_OBJECTS:pegasus_client_impl_ob
 target_link_libraries(pegasus_client_shared PRIVATE
     pegasus_base
     dsn_runtime
-    dsn_replication_client
+    dsn_client
     dsn_replication_common
     thrift)
 install(TARGETS pegasus_client_shared DESTINATION "lib")

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -18,7 +18,6 @@ set(MY_PROJ_LIBS
     dsn.block_service.fds
     dsn.block_service
     dsn.failure_detector
-    dsn.failure_detector.multimaster
     dsn.replication.zookeeper_provider
     RocksDB::rocksdb
     pegasus_reporter

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -13,7 +13,7 @@ set(MY_PROJ_LIBS
     dsn_replica_server
     dsn_meta_server
     dsn_replication_common
-    dsn.replication.ddlclient
+    dsn_client
     dsn.block_service.local
     dsn.block_service.fds
     dsn.block_service

--- a/src/server/test/CMakeLists.txt
+++ b/src/server/test/CMakeLists.txt
@@ -18,7 +18,7 @@ set(MY_PROJ_LIBS
         dsn_replica_server
         dsn_meta_server
         dsn_replication_common
-        dsn.replication.ddlclient
+        dsn_client
         dsn.block_service.local
         dsn.block_service.fds
         dsn.block_service

--- a/src/server/test/CMakeLists.txt
+++ b/src/server/test/CMakeLists.txt
@@ -23,7 +23,6 @@ set(MY_PROJ_LIBS
         dsn.block_service.fds
         dsn.block_service
         dsn.failure_detector
-        dsn.failure_detector.multimaster
         dsn.replication.zookeeper_provider
         pegasus_reporter
         RocksDB::rocksdb

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -15,7 +15,7 @@ set(MY_PROJ_LIBS
     dsn.replication.tool
     dsn_replica_server
     dsn_replication_common
-    dsn.replication.ddlclient
+    dsn_client
     dsn.block_service.local
     dsn.block_service.fds
     dsn.block_service

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -20,7 +20,6 @@ set(MY_PROJ_LIBS
     dsn.block_service.fds
     dsn.block_service
     dsn.failure_detector
-    dsn.failure_detector.multimaster
     pegasus_client_static
     galaxy-fds-sdk-cpp
     PocoNet

--- a/src/test/function_test/CMakeLists.txt
+++ b/src/test/function_test/CMakeLists.txt
@@ -11,7 +11,7 @@ set(MY_PROJ_SRC "")
 set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS
-    dsn.replication.ddlclient
+    dsn_client
     dsn_replication_common
     pegasus_client_static
     gtest

--- a/src/test/function_test/global_env.cpp
+++ b/src/test/function_test/global_env.cpp
@@ -14,7 +14,6 @@
 #include <arpa/inet.h>
 
 #include "global_env.h"
-global_env global_env::inst;
 
 global_env::global_env()
 {

--- a/src/test/function_test/global_env.h
+++ b/src/test/function_test/global_env.h
@@ -7,14 +7,12 @@
 #include <string>
 #include <sstream>
 
-class global_env
+class global_env : public dsn::utils::singleton<global_env>
 {
 public:
     std::string _pegasus_root;
     std::string _working_dir;
     std::string _host_ip;
-
-    static global_env &instance() { return inst; }
 
 private:
     global_env();
@@ -23,5 +21,6 @@ private:
 
     void get_hostip();
     void get_dirs();
-    static global_env inst;
+
+    friend dsn::utils::singleton<global_env>;
 };

--- a/src/test/kill_test/CMakeLists.txt
+++ b/src/test/kill_test/CMakeLists.txt
@@ -13,7 +13,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 set(MY_PROJ_LIBS
     pegasus_base
     pegasus_client_static
-    dsn.replication.ddlclient
+    dsn_client
     dsn_replication_common
     dsn_dist_cmd
     dsn_runtime

--- a/src/test/upgrade_test/CMakeLists.txt
+++ b/src/test/upgrade_test/CMakeLists.txt
@@ -13,7 +13,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 set(MY_PROJ_LIBS
     pegasus_base
     pegasus_client_static
-    dsn.replication.ddlclient
+    dsn_client
     dsn_replication_common
     dsn_runtime
     )


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

1.change lib name: In the refactors of rdsn, some lib name were changed. for example: name of client lib is changed from `dsn.repliation.ddlclient` to `dsn.client`, etc. so in pegasus,  we should change it synchronously.

2.use `dsn::utils::singleton` to refactor `global_env`