### PR TITLE
refactor: add the dependend lib which name is dsn_utils

### DIFF
--- a/src/base/test/CMakeLists.txt
+++ b/src/base/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS
         dsn_runtime
+        dsn_utils
         pegasus_base
         gtest)
 

--- a/src/client_lib/CMakeLists.txt
+++ b/src/client_lib/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(pegasus_client_shared SHARED $<TARGET_OBJECTS:pegasus_client_impl_ob
 target_link_libraries(pegasus_client_shared PRIVATE
     pegasus_base
     dsn_runtime
+    dsn_utils
     dsn_client
     dsn_replication_common
     thrift)

--- a/src/geo/bench/CMakeLists.txt
+++ b/src/geo/bench/CMakeLists.txt
@@ -16,6 +16,7 @@ set(MY_PROJ_LIBS
         s2
         pegasus_client_static
         RocksDB::rocksdb
+        dsn_utils
         )
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem)

--- a/src/geo/test/CMakeLists.txt
+++ b/src/geo/test/CMakeLists.txt
@@ -15,6 +15,7 @@ set(MY_PROJ_LIBS
         s2testing
         s2
         pegasus_client_static
+        dsn_utils
         gtest)
 
 set(MY_BOOST_LIBS Boost::system Boost::filesystem)

--- a/src/redis_protocol/proxy_lib/CMakeLists.txt
+++ b/src/redis_protocol/proxy_lib/CMakeLists.txt
@@ -16,6 +16,7 @@ add_definitions(-Wno-attributes)
 dsn_add_static_library()
 
 target_link_libraries(${MY_PROJ_NAME} PRIVATE RocksDB::rocksdb
+                                              dsn_utils
                                               pegasus_base) # TODO(huangwei5): dsn_add_static_library doesnt link libs, need fix
 
 target_include_directories(${MY_PROJ_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MY_PROJ_LIBS
     dsn.block_service
     dsn.failure_detector
     dsn.replication.zookeeper_provider
+    dsn_utils
     RocksDB::rocksdb
     pegasus_reporter
     pegasus_base

--- a/src/server/test/CMakeLists.txt
+++ b/src/server/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(MY_PROJ_LIBS
         dsn.block_service
         dsn.failure_detector
         dsn.replication.zookeeper_provider
+        dsn_utils
         pegasus_reporter
         RocksDB::rocksdb
         pegasus_client_static

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -16,6 +16,7 @@ set(MY_PROJ_LIBS
     dsn_replica_server
     dsn_replication_common
     dsn_client
+    dsn_utils
     dsn.block_service.local
     dsn.block_service.fds
     dsn.block_service

--- a/src/test/bench_test/CMakeLists.txt
+++ b/src/test/bench_test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS
         pegasus_client_static
+        dsn_utils
         RocksDB::rocksdb
         )
 

--- a/src/test/function_test/CMakeLists.txt
+++ b/src/test/function_test/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 set(MY_PROJ_LIBS
     dsn_client
     dsn_replication_common
+    dsn_utils
     pegasus_client_static
     gtest
     )

--- a/src/test/kill_test/CMakeLists.txt
+++ b/src/test/kill_test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MY_PROJ_LIBS
     dsn_replication_common
     dsn_dist_cmd
     dsn_runtime
+    dsn_utils
     )
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config.ini")
 

--- a/src/test/pressure_test/CMakeLists.txt
+++ b/src/test/pressure_test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(MY_SRC_SEARCH_MODE "GLOB")
 
 set(MY_PROJ_LIBS
     pegasus_client_static
+    dsn_utils
     )
 
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config-pressure.ini")

--- a/src/test/upgrade_test/CMakeLists.txt
+++ b/src/test/upgrade_test/CMakeLists.txt
@@ -16,6 +16,7 @@ set(MY_PROJ_LIBS
     dsn_client
     dsn_replication_common
     dsn_runtime
+    dsn_utils
     )
 set(MY_BINPLACES "${CMAKE_CURRENT_SOURCE_DIR}/config.ini")
 


### PR DESCRIPTION
In pr https://github.com/XiaoMi/rdsn/pull/517, we make utils decoupled from dsn_runtime. So in pegasus, we should add the depend of dsn_utils implicitly.


