### PR TITLE
fix: compile failed under the "g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11)"

### DIFF
--- a/src/server/meta_store.cpp
+++ b/src/server/meta_store.cpp
@@ -79,11 +79,11 @@ uint64_t meta_store::get_decree_from_readonly_db(rocksdb::DB *db,
     }
     auto status = db->Get(rd_opts, cf, key, &data);
     if (status.ok()) {
-        dassert(dsn::buf2uint64(data, *value),
-                "rocksdb {} get {} from meta column family got error value {}",
-                db->GetName(),
-                key,
-                data);
+        dassert_f(dsn::buf2uint64(data, *value),
+                  "rocksdb {} get {} from meta column family got error value {}",
+                  db->GetName(),
+                  key,
+                  data);
         return ::dsn::ERR_OK;
     }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Compile failed as follow env:
g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11)
cmake version 3.5.2
```
/home/jiashuo1/work/pegasus/src/server/meta_store.cpp: In static member function ‘static dsn::error_code pegasus::server::meta_store::get_value_from_meta_cf(rocksdb::DB*, rocksdb::ColumnFamilyHandle*, bool, const string&, uint64_t*)’:
/home/jiashuo1/work/pegasus/DSN_ROOT/include/dsn/c/api_utilities.h:90:78: error: cannot pass objects of non-trivially-copyable type ‘const string {aka const class std::basic_string<char>}’ through ‘...’
             dsn_logf(__FILENAME__, __FUNCTION__, __LINE__, level, __VA_ARGS__);                    \
                                                                              ^
/home/jiashuo1/work/pegasus/DSN_ROOT/include/dsn/c/api_utilities.h:101:13: note: in expansion of macro ‘dlog’
             dlog(LOG_LEVEL_FATAL, __VA_ARGS__);                                                    \
             ^
/home/jiashuo1/work/pegasus/src/server/meta_store.cpp:82:9: note: in expansion of macro ‘dassert’
         dassert(dsn::buf2uint64(data, *value),
         ^
/home/jiashuo1/work/pegasus/DSN_ROOT/include/dsn/c/api_utilities.h:90:78: error: cannot pass objects of non-trivially-copyable type ‘const string {aka const class std::basic_string<char>}’ through ‘...’
             dsn_logf(__FILENAME__, __FUNCTION__, __LINE__, level, __VA_ARGS__);                    \
                                                                              ^
/home/jiashuo1/work/pegasus/DSN_ROOT/include/dsn/c/api_utilities.h:101:13: note: in expansion of macro ‘dlog’
             dlog(LOG_LEVEL_FATAL, __VA_ARGS__);                                                    \
             ^
/home/jiashuo1/work/pegasus/src/server/meta_store.cpp:82:9: note: in expansion of macro ‘dassert’
         dassert(dsn::buf2uint64(data, *value),
         ^
/home/jiashuo1/work/pegasus/DSN_ROOT/include/dsn/c/api_utilities.h:90:78: error: cannot pass objects of non-trivially-copyable type ‘std::string {aka class std::basic_string<char>}’ through ‘...’
             dsn_logf(__FILENAME__, __FUNCTION__, __LINE__, level, __VA_ARGS__);                    \
                                                                              ^
/home/jiashuo1/work/pegasus/DSN_ROOT/include/dsn/c/api_utilities.h:101:13: note: in expansion of macro ‘dlog’
             dlog(LOG_LEVEL_FATAL, __VA_ARGS__);                                                    \
             ^
/home/jiashuo1/work/pegasus/src/server/meta_store.cpp:82:9: note: in expansion of macro ‘dassert’
         dassert(dsn::buf2uint64(data, *value),

```

### What is changed and how it works?
Change `dassert` to `dassert_f`(https://github.com/XiaoMi/pegasus/blob/c94bc3e9264aa3488e80494ec0d74ab40d8b0310/src/server/meta_store.cpp#L82) 
**or** 
Compile it on g++ (Ubuntu 5.4.0-6ubuntu1~16.04.12) 5.4.0 20160609
 
Consider the more common env, this pr choose "Change `dassert` to `dassert_f`"

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
