### PR TITLE
fix: delete outdated algorithm of table_hotspot_policy

### DIFF
--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -314,8 +314,6 @@ hotspot_calculator *info_collector::get_hotspot_calculator(const std::string &ap
     std::unique_ptr<hotspot_policy> policy;
     if (_hotspot_detect_algorithm == "hotspot_algo_qps_variance") {
         policy.reset(new hotspot_algo_qps_variance());
-    } else if (_hotspot_detect_algorithm == "hotspot_algo_qps_skew") {
-        policy.reset(new hotspot_algo_qps_skew());
     } else {
         dwarn("hotspot detection is disabled");
         _hotspot_calculator_store[app_name_pcount] = nullptr;

--- a/src/server/table_hotspot_policy.h
+++ b/src/server/table_hotspot_policy.h
@@ -25,25 +25,6 @@ public:
                           std::vector<::dsn::perf_counter_wrapper> &perf_counters) = 0;
 };
 
-class hotspot_algo_qps_skew : public hotspot_policy
-{
-public:
-    void analysis(const std::queue<std::vector<hotspot_partition_data>> &hotspot_app_data,
-                  std::vector<::dsn::perf_counter_wrapper> &perf_counters)
-    {
-        const auto &anly_data = hotspot_app_data.back();
-        double min_total_qps = INT_MAX;
-        for (auto partition_anly_data : anly_data) {
-            min_total_qps = std::min(min_total_qps, partition_anly_data.total_qps);
-        }
-        min_total_qps = std::max(1.0, min_total_qps);
-        dassert(anly_data.size() == perf_counters.size(), "partition counts error, please check");
-        for (int i = 0; i < perf_counters.size(); i++) {
-            perf_counters[i]->set(anly_data[i].total_qps / min_total_qps);
-        }
-    }
-};
-
 // PauTa Criterion
 class hotspot_algo_qps_variance : public hotspot_policy
 {
@@ -114,7 +95,6 @@ private:
     static const int kMaxQueueSize = 100;
 
     FRIEND_TEST(table_hotspot_policy, hotspot_algo_qps_variance);
-    FRIEND_TEST(table_hotspot_policy, hotspot_algo_qps_skew);
 };
 } // namespace server
 } // namespace pegasus

--- a/src/server/test/pegasus_tablehotspot_test.cpp
+++ b/src/server/test/pegasus_tablehotspot_test.cpp
@@ -9,23 +9,6 @@
 namespace pegasus {
 namespace server {
 
-TEST(table_hotspot_policy, hotspot_algo_qps_skew)
-{
-    std::vector<row_data> test_rows(2);
-    test_rows[0].get_qps = 1234.0;
-    test_rows[1].get_qps = 4321.0;
-    std::unique_ptr<hotspot_policy> policy(new hotspot_algo_qps_skew());
-    hotspot_calculator test_hotspot_calculator("TEST", 2, std::move(policy));
-    test_hotspot_calculator.aggregate(test_rows);
-    test_hotspot_calculator.start_alg();
-    std::vector<double> result(2);
-    for (int i = 0; i < test_hotspot_calculator._points.size(); i++) {
-        result[i] = test_hotspot_calculator._points[i]->get_value();
-    }
-    std::vector<double> expect_vector{1, 3};
-    ASSERT_EQ(expect_vector, result);
-}
-
 TEST(table_hotspot_policy, hotspot_algo_qps_variance)
 {
     std::vector<row_data> test_rows(8);


### PR DESCRIPTION
This algorithm cannot support hotkey detection, so I decide to delete it.