### PR TITLE
fix: change the construction parameters of hotspot calculator

### DIFF
--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -322,7 +322,7 @@ hotspot_calculator *info_collector::get_hotspot_calculator(const std::string &ap
         return nullptr;
     }
     hotspot_calculator *calculator =
-        new hotspot_calculator(app_name_pcount, partition_num, std::move(policy));
+        new hotspot_calculator(app_name, partition_num, std::move(policy));
     _hotspot_calculator_store[app_name_pcount] = calculator;
     return calculator;
 }


### PR DESCRIPTION
This PR changes construction parameters of hotspot_calculator, it won't change the function of origin code, but it is helpful for hotkey detection.